### PR TITLE
Modularized SimpleShaderInspector class

### DIFF
--- a/Editor/Controls/ColorControl.cs
+++ b/Editor/Controls/ColorControl.cs
@@ -14,6 +14,11 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         public bool ShowAlphaValue { get; set; }
 
         /// <summary>
+        /// Selected color of the property stored in this control.
+        /// </summary>
+        public Color SelectedColor => Property.colorValue;
+
+        /// <summary>
         /// Default constructor of <see cref="ColorControl"/>
         /// </summary>
         /// <param name="propertyName">Material property name.</param>

--- a/Editor/Controls/EnumControl.cs
+++ b/Editor/Controls/EnumControl.cs
@@ -11,6 +11,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls
     {
         private readonly GUIContent[] _options;
 
+        public TEnum SelectedOption => (TEnum)Enum.ToObject(typeof(TEnum) , Property.floatValue);
+
         /// <summary>
         /// Default constructor of <see cref="EnumControl<TEnum>"/>
         /// </summary>

--- a/Editor/Controls/GradientTextureControl.cs
+++ b/Editor/Controls/GradientTextureControl.cs
@@ -251,8 +251,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             GUI.backgroundColor = GradientSaveButtonColor;
             if (GUILayout.Button(AdditionalContent[5].Content, GradientSaveButtonStyle))
             {
-                string path = SimpleShaderInspector.GetTextureDestinationPath((Material)Property.targets[0], PropertyName + "_gradient.png");
-                Property.textureValue = SimpleShaderInspector.SaveAndGetTexture(_gradient.GetTexture(), path, TextureWrapMode.Clamp);
+                string path = SSIHelper.GetTextureDestinationPath((Material)Property.targets[0], PropertyName + "_gradient.png");
+                Property.textureValue = SSIHelper.SaveAndGetTexture(_gradient.GetTexture(), path, TextureWrapMode.Clamp);
                 HasPropertyUpdated = true;
                 _previousTextures = null;
                 Selection.selectionChanged -= ResetGradientTexture;
@@ -334,7 +334,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         {
             if (!texture.isReadable)
             {
-                SimpleShaderInspector.SetTextureImporterReadable(texture, true);
+                SSIHelper.SetTextureImporterReadable(texture, true);
             }
             _gradient = new GradientTexture((int)_rampWidth);
             _blendMode = GradientBlendMode.Linear;

--- a/Editor/Controls/TextureControl.cs
+++ b/Editor/Controls/TextureControl.cs
@@ -101,7 +101,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             }
             if (_hasExtra2)
             {
-                materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property, AdditionalProperties[1].Property);
+                //materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property, AdditionalProperties[1].Property);
             }
             else if (_hasExtra1)
             {

--- a/Editor/Controls/TextureControl.cs
+++ b/Editor/Controls/TextureControl.cs
@@ -101,7 +101,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             }
             if (_hasExtra2)
             {
-                //materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property, AdditionalProperties[1].Property);
+                materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property, AdditionalProperties[1].Property);
             }
             else if (_hasExtra1)
             {

--- a/Editor/Controls/TextureGeneratorControl.cs
+++ b/Editor/Controls/TextureGeneratorControl.cs
@@ -155,18 +155,18 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             GeneratorInputColor = Color.white;
             GeneratorSaveButtonColor = Color.white;
 
-            _baseContent = AdditionalContentExtensions.CreatLocalizationArrayFromNames(_baseNames);
+            _baseContent = AdditionalContentExtensions.CreateLocalizationArrayFromNames(_baseNames);
 
             // Texture exclusive content
             if (_containsTextures)
             {
-                _textureContent = AdditionalContentExtensions.CreatLocalizationArrayFromNames(_textureNames);
+                _textureContent = AdditionalContentExtensions.CreateLocalizationArrayFromNames(_textureNames);
             }
 
             // Color exclusive content
             if (_containsTextures)
             {
-                _colorContent = AdditionalContentExtensions.CreatLocalizationArrayFromNames(_colorNames);
+                _colorContent = AdditionalContentExtensions.CreateLocalizationArrayFromNames(_colorNames);
             }
 
             _namesContent = new AdditionalLocalization[_inputs.Count];
@@ -310,7 +310,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             _resultTex.ReadPixels(new Rect(0, 0, _result.width, _result.height), 0, 0);
             RenderTexture.active = null;
             _resultTex.Apply(true);
-            Property.textureValue = SimpleShaderInspector.SaveAndGetTexture(_resultTex, SimpleShaderInspector.GetTextureDestinationPath((Material)Property.targets[0], PropertyName + ".png"));
+            Property.textureValue = SSIHelper.SaveAndGetTexture(_resultTex, SSIHelper.GetTextureDestinationPath((Material)Property.targets[0], PropertyName + ".png"));
         }
     }
 

--- a/Editor/IAdditionalLocalization.cs
+++ b/Editor/IAdditionalLocalization.cs
@@ -41,7 +41,7 @@ namespace VRLabs.SimpleShaderInspectors
             }
         }
 
-        public static AdditionalLocalization[] CreatLocalizationArrayFromNames(string[] contentNames)
+        public static AdditionalLocalization[] CreateLocalizationArrayFromNames(string[] contentNames)
         {
             AdditionalLocalization[] obj = new AdditionalLocalization[contentNames.Length];
             for (int i = 0; i < contentNames.Length; i++)

--- a/Editor/IAdditionalProperties.cs
+++ b/Editor/IAdditionalProperties.cs
@@ -28,7 +28,7 @@ namespace VRLabs.SimpleShaderInspectors
         /// <summary>
         /// Array containing the index needed to fetch.
         /// </summary>
-        private int _propertyIndex;
+        private int _propertyIndex = -2;
 
         /// <summary>
         /// MaterialProperty containing the additional property needed by the control.
@@ -47,20 +47,19 @@ namespace VRLabs.SimpleShaderInspectors
         // Fetch and store the index of the needed material property.
         internal void SetPropertyIndex(MaterialProperty[] properties)
         {
-            _propertyIndex = SimpleShaderInspector.FindPropertyIndex(PropertyName, properties);
+            _propertyIndex = SSIHelper.FindPropertyIndex(PropertyName, properties);
         }
 
         // Fetch the material property based on the index.
         internal void FetchProperty(MaterialProperty[] properties)
         {
+            if (_propertyIndex == -2)
+                SetPropertyIndex(properties);
+
             if (_propertyIndex != -1)
-            {
                 Property = properties[_propertyIndex];
-            }
             else
-            {
                 Property = null;
-            }
         }
     }
 }

--- a/Editor/ISimpleShaderInspector.cs
+++ b/Editor/ISimpleShaderInspector.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace VRLabs.SimpleShaderInspectors
+{
+    public interface ISimpleShaderInspector : IControlContainer
+    {
+        Material[] Materials { get; }
+
+        Shader Shader { get; }
+    }
+}

--- a/Editor/ISimpleShaderInspector.cs.meta
+++ b/Editor/ISimpleShaderInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65da5c946271f614a86ea860ba201f25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MaterialArrayHelper.cs
+++ b/Editor/MaterialArrayHelper.cs
@@ -1,0 +1,90 @@
+using UnityEngine;
+
+namespace VRLabs.SimpleShaderInspectors
+{
+    public static class MaterialArrayHelper
+    {
+        /// <summary>
+        /// Sets a keyword state to all materials in the array.
+        /// </summary>
+        /// <param name="materials">Material array this method extends to.</param>
+        /// <param name="keyword">The keyword that is being toggled.</param>
+        /// <param name="state">Toggle value.</param>
+        public static void SetKeyword(this Material[] materials, string keyword, bool state)
+        {
+            foreach (var m in materials)
+            {
+                if (state)
+                    m.EnableKeyword(keyword);
+                else
+                    m.DisableKeyword(keyword);
+            }
+        }
+
+        /// <summary>
+        /// Gets the mixed value state of a keyword on the materials array
+        /// </summary>
+        /// <param name="materials">Material array this method extends to.</param>
+        /// <param name="keyword">The keyword to check against.</param>
+        /// <returns>True if the keyword has mixed values, false otherwise.</returns>
+        public static bool IsKeywordMixedValue(this Material[] materials, string keyword)
+        {
+            bool reference = materials[0].IsKeywordEnabled(keyword);
+            foreach (var m in materials)
+            {
+                if (m.IsKeywordEnabled(keyword) != reference)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Set override tag to all materials in the array.
+        /// </summary>
+        /// <param name="materials">Material array this method extends to.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="value">Value of the tag.</param>
+        public static void SetOverrideTag(this Material[] materials, string tagName, string value)
+        {
+            foreach (var m in materials)
+                m.SetOverrideTag(tagName, value);
+        }
+
+        /// <summary>
+        /// Set int to all materials in the array.
+        /// </summary>
+        /// <param name="materials">Material array this method extends to.</param>
+        /// <param name="name">Name of the int.</param>
+        /// <param name="value">Value of the int.</param>
+        public static void SetInt(this Material[] materials, string name, int value)
+        {
+            foreach (var m in materials)
+                m.SetInt(name, value);
+        }
+
+        /// <summary>
+        /// Set vector to all materials in the array.
+        /// </summary>
+        /// <param name="materials">Material array this method extends to.</param>
+        /// <param name="name">Name of the Vector4.</param>
+        /// <param name="value">Value of the Vector4.</param>
+        public static void SetVector(this Material[] materials, string name, Vector4 value)
+        {
+            foreach (var m in materials)
+                m.SetVector(name, value);
+        }
+
+        /// <summary>
+        /// Set render queue to all materials in the array.
+        /// </summary>
+        /// <param name="materials">Material array this method extends to.</param>
+        /// <param name="queue">Render queue value.</param>
+        public static void SetRenderQueue(this Material[] materials, int queue)
+        {
+            foreach (var m in materials)
+                m.renderQueue = queue;
+        }
+    }
+}

--- a/Editor/MaterialArrayHelper.cs.meta
+++ b/Editor/MaterialArrayHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b41d8abd48c2bf644888ca5394f1b3f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/PropertyControl.cs
+++ b/Editor/PropertyControl.cs
@@ -11,7 +11,7 @@ namespace VRLabs.SimpleShaderInspectors
         /// <summary>
         /// Integer containing the index of the property of this control.
         /// </summary>
-        private int _propertyIndex;
+        private int _propertyIndex = -2;
 
         /// <summary>
         /// Name of the property shown by this control.
@@ -50,19 +50,18 @@ namespace VRLabs.SimpleShaderInspectors
 
         internal void SetPropertyIndex(MaterialProperty[] properties)
         {
-            _propertyIndex = SimpleShaderInspector.FindPropertyIndex(PropertyName, properties);
+            _propertyIndex = SSIHelper.FindPropertyIndex(PropertyName, properties);
         }
 
         internal void FetchProperty(MaterialProperty[] properties)
         {
+            if(_propertyIndex == -2)
+                SetPropertyIndex(properties);
+
             if (_propertyIndex != -1)
-            {
                 Property = properties[_propertyIndex];
-            }
             else
-            {
                 Property = null;
-            }
         }
     }
     public static partial class BaseControlExtensions

--- a/Editor/SSIHelper.cs
+++ b/Editor/SSIHelper.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace VRLabs.SimpleShaderInspectors
+{
+    public static class SSIHelper
+    {
+        /// <summary>
+        /// Fetches properties for all the given controls.
+        /// </summary>
+        /// <param name="controls">Controls needing to fetch properties.</param>
+        /// <param name="properties">Property array to fetch properties from.</param>
+        public static void FetchProperties(this IEnumerable<SimpleControl> controls, MaterialProperty[] properties)
+        {
+            foreach (var control in controls)
+            {
+                if (control is PropertyControl pr)
+                    pr.FetchProperty(properties);
+
+                if (control is IAdditionalProperties add)
+                {
+                    for (int j = 0; j < add.AdditionalProperties.Length; j++)
+                        add.AdditionalProperties[j].FetchProperty(properties);
+                }
+
+                if (control is IControlContainer con)
+                    con.Controls.FetchProperties(properties);
+            }
+        }
+
+        /// <summary>
+        /// Set the inspector of each control of the list.
+        /// </summary>
+        /// <param name="controls">Controls this method extends from.</param>
+        /// <param name="inspector">Inspector to set</param>
+        /// <param name="recursive">Is the set recursive to child controls</param>
+        public static void SetInspector(this IEnumerable<SimpleControl> controls, ISimpleShaderInspector inspector, bool recursive = true)
+        {
+            foreach (var control in controls)
+            {
+                control.Inspector = inspector;
+                if (recursive && control is IControlContainer con)
+                    con.Controls.SetInspector(inspector);
+            }
+        }
+
+        /// <summary>
+        /// Find a material property from its name.
+        /// </summary>
+        /// <param name="propertyName">Name of the material proeperty.</param>
+        /// <param name="properties">Array of material properties to search from.</param>
+        /// <param name="propertyIsMandatory">Boolean indicating if it's mandatory to find the requested material property</param>
+        /// <returns>The material property with the wanted name.</returns>
+        internal static int FindPropertyIndex(string propertyName, MaterialProperty[] properties, bool propertyIsMandatory = false)
+        {
+            for (int i = 0; i < properties.Length; i++)
+            {
+                if (properties[i] != null && properties[i].name == propertyName)
+                    return i;
+            }
+
+            // We assume all required properties can be found, otherwise something is broken.
+            if (propertyIsMandatory)
+                throw new ArgumentException("Could not find MaterialProperty: '" + propertyName + "', Num properties: " + properties.Length);
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Finds all controls that implement the INonAnimatableProperty interface.
+        /// </summary>
+        /// <param name="controls">Controls to search from</param>
+        /// <returns>An enumerable containing all INonAnimarableProperty instances found</returns>
+        public static IEnumerable<INonAnimatableProperty> FindNonAnimatablePropertyControls(this IEnumerable<SimpleControl> controls)
+        {
+            List<INonAnimatableProperty> nonAnimatablePropertyControls = new List<INonAnimatableProperty>();
+            foreach(var control in controls)
+            {
+                if(control is INonAnimatableProperty c)
+                    nonAnimatablePropertyControls.Add(c);
+
+                if(control is IControlContainer container)
+                    nonAnimatablePropertyControls.AddRange(container.Controls.FindNonAnimatablePropertyControls());
+            }
+            return nonAnimatablePropertyControls;
+        }
+
+        /// <summary>
+        /// Updates properties that are set to not be recorded during animation recording.
+        /// </summary>
+        /// <param name="controls">Controls to check.</param>
+        /// <param name="materialEditor">Material editor.</param>
+        /// <param name="updateOutsideAnimation">If the animations will actually be changed outside of animation recording</param>
+        public static void UpdateNonAnimatableProperties(IEnumerable<INonAnimatableProperty> controls, MaterialEditor materialEditor, bool updateOutsideAnimation = true)
+        {
+            List<INonAnimatableProperty> propertiesNeedingUpdate = new List<INonAnimatableProperty>();
+            foreach(var control in controls)
+            {
+                if (control.NonAnimatablePropertyChanged)
+                    propertiesNeedingUpdate.Add(control);
+            }
+
+            if (propertiesNeedingUpdate.Count == 0) return;
+
+            if (updateOutsideAnimation)
+            {
+                // Reflection bs to get which animation window is recording
+                System.Reflection.Assembly editorAssembly = typeof(Editor).Assembly;
+                Type windowType = editorAssembly.GetType("UnityEditorInternal.AnimationWindowState");
+
+                System.Reflection.PropertyInfo isRecordingProp = windowType.GetProperty
+                    ("recording", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+
+                UnityEngine.Object[] windowInstances = Resources.FindObjectsOfTypeAll(windowType);
+                UnityEngine.Object recordingInstance = null;
+
+                for (int i = 0; i < windowInstances.Length; i++)
+                {
+                    bool isRecording = (bool)isRecordingProp.GetValue
+                        (windowInstances[i], null);
+
+                    if (isRecording)
+                    {
+                        recordingInstance = windowInstances[i];
+                        break;
+                    }
+                }
+                if (recordingInstance != null)
+                {
+                    System.Reflection.MethodBase stopRecording = windowType.GetMethod
+                        ("StopRecording", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+                    System.Reflection.MethodBase startRecording = windowType.GetMethod
+                        ("StartRecording", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+
+                    stopRecording?.Invoke(recordingInstance, null);
+                    SetNonAnimatableProperties(materialEditor, propertiesNeedingUpdate);
+                    startRecording?.Invoke(recordingInstance, null);
+                }
+                else
+                {
+                    SetNonAnimatableProperties(materialEditor, propertiesNeedingUpdate);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < propertiesNeedingUpdate.Count; i++)
+                    SetNonAnimatableProperties(materialEditor, propertiesNeedingUpdate);
+            }
+        }
+
+        public static void SetNonAnimatableProperties(MaterialEditor materialEditor, IEnumerable<INonAnimatableProperty> nonAnimatableProperties)
+        {
+            foreach(var nonAnimatableProperty in nonAnimatableProperties)
+            {
+                nonAnimatableProperty.UpdateNonAnimatableProperty(materialEditor);
+                nonAnimatableProperty.NonAnimatablePropertyChanged = false;
+            }
+        }
+
+        /// <summary>
+        /// Get a path to save a texture relative to the material.
+        /// </summary>
+        /// <param name="mat">Material.</param>
+        /// <param name="name">Name of the texture.</param>
+        /// <returns>A path for the texture to save.</returns>
+        public static string GetTextureDestinationPath(Material mat, string name)
+        {
+            string path = AssetDatabase.GetAssetPath(mat);
+            path = Directory.GetParent(path).FullName;
+            string pathParent = Directory.GetParent(path).FullName;
+
+            if (Directory.Exists(pathParent + "/Textures/"))
+                return pathParent + "/Textures/" + mat.name + name;
+            else
+                return path + "/" + mat.name + name;
+        }
+
+        /// <summary>
+        /// Saves a texture to a specified path.
+        /// </summary>
+        /// <param name="texture">Texture to save.</param>
+        /// <param name="path">path where you want to save the texture.</param>
+        /// <param name="mode">Texture wrap mode (default: Repeat).</param>
+        public static void SaveTexture(Texture2D texture, string path, TextureWrapMode mode = TextureWrapMode.Repeat)
+        {
+            byte[] bytes = texture.EncodeToPNG();
+
+            System.IO.File.WriteAllBytes(path, bytes);
+            AssetDatabase.Refresh();
+            path = path.Substring(path.LastIndexOf("Assets"));
+            TextureImporter t = AssetImporter.GetAtPath(path) as TextureImporter;
+            t.wrapMode = mode;
+            t.isReadable = true;
+            AssetDatabase.ImportAsset(path);
+        }
+
+        /// <summary>
+        /// Saves a texture to a specified path, and returns a reference of the new asset.
+        /// </summary>
+        /// <param name="texture">Texture to save.</param>
+        /// <param name="path">path where you want to save the texture.</param>
+        /// <param name="mode">Texture wrap mode (default: Repeat).</param>
+        /// <returns>A Texture2D that references the newly created asset.</returns>
+        public static Texture2D SaveAndGetTexture(Texture2D texture, string path, TextureWrapMode mode = TextureWrapMode.Repeat)
+        {
+            SaveTexture(texture, path, mode);
+            path = path.Substring(path.LastIndexOf("Assets"));
+            return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+        }
+
+        /// <summary>
+        /// Set the texture readable state.
+        /// </summary>
+        /// <param name="texture">Texture</param>
+        /// <param name="isReadable">Does the texture need to be readable.</param>
+        public static void SetTextureImporterReadable(Texture2D texture, bool isReadable)
+        {
+            if (texture == null) return;
+
+            string assetPath = AssetDatabase.GetAssetPath(texture);
+            var tImporter = AssetImporter.GetAtPath(assetPath) as TextureImporter;
+            if (tImporter != null)
+            {
+                tImporter.textureType = TextureImporterType.Default;
+                tImporter.isReadable = isReadable;
+                AssetDatabase.ImportAsset(assetPath);
+                //AssetDatabase.Refresh();
+            }
+        }
+
+        public static void SetTextureImporterAlpha(Texture2D texture, bool alphaIsTransparency)
+        {
+            if (texture == null) return;
+
+            string assetPath = AssetDatabase.GetAssetPath(texture);
+            var tImporter = AssetImporter.GetAtPath(assetPath) as TextureImporter;
+            if (tImporter != null)
+            {
+                tImporter.textureType = TextureImporterType.Default;
+                tImporter.alphaIsTransparency = alphaIsTransparency;
+                AssetDatabase.ImportAsset(assetPath);
+            }
+        }
+    }
+}

--- a/Editor/SSIHelper.cs.meta
+++ b/Editor/SSIHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5e6541663be9fd40818747807c63fa4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/SimpleControl.cs
+++ b/Editor/SimpleControl.cs
@@ -10,6 +10,10 @@ namespace VRLabs.SimpleShaderInspectors
     public abstract class SimpleControl
     {
         /// <summary>
+        /// Inspector that contains this control.
+        /// </summary>
+        public ISimpleShaderInspector Inspector { get; set; }
+        /// <summary>
         /// GuiContent set by the inspector.
         /// </summary>
         public GUIContent Content { get; set; }

--- a/Editor/SimpleShaderInspector.cs
+++ b/Editor/SimpleShaderInspector.cs
@@ -2,19 +2,17 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
-using System.Diagnostics;
 using System;
 using Object = UnityEngine.Object;
+
 
 namespace VRLabs.SimpleShaderInspectors
 {
     /// <summary>
     /// Base class for creating new inspectors.
     /// </summary>
-    public abstract class SimpleShaderInspector : ShaderGUI, IControlContainer
+    public abstract class SimpleShaderInspector : ShaderGUI, ISimpleShaderInspector
     {
-        // Reference to the shader used
-        private Shader _shader;
         // Array containing all found languages for a specific GUI.
         private string[] _languages;
         // String containing the selected language.
@@ -28,6 +26,10 @@ namespace VRLabs.SimpleShaderInspectors
         // Bool that determines if the child class added some controls or not.
         private bool _doesContainControls = true;
 
+        private bool ContainsNonAnimatableProperties => _nonAnimatablePropertyControls.Count > 0;
+
+        private List<INonAnimatableProperty> _nonAnimatablePropertyControls;
+
         private Texture2D _logo;
 
         /// <summary>
@@ -38,7 +40,10 @@ namespace VRLabs.SimpleShaderInspectors
         /// <summary>
         /// Array of selected materials
         /// </summary>
-        public Material[] Materials { get; set; }
+        public Material[] Materials { get; private set; }
+
+        // Reference to the shader used
+        public Shader Shader { get; private set; }
 
         /// <summary>
         /// List of controls.
@@ -53,7 +58,7 @@ namespace VRLabs.SimpleShaderInspectors
         /// <summary>
         /// Boolean value that defines if the inspector should check for non animatable properties.
         /// </summary>
-        protected bool HasNonAnimatableProperties { get; set; }
+        protected bool NeedsNonAnimatableUpdate { get; set; }
 
         /// <summary>
         /// Inizialization method where all the controls are instanced. You need to override it.
@@ -77,6 +82,12 @@ namespace VRLabs.SimpleShaderInspectors
         protected virtual void StartChecks(MaterialEditor materialEditor) { }
 
         /// <summary>
+        /// Check changes happened to properties.
+        /// </summary>
+        /// <param name="materialEditor">material editor that uses this GUI.</param>
+        protected virtual void CheckChanges(MaterialEditor materialEditor) { }
+
+        /// <summary>
         /// Method called when updating UI. Cannot be overridden in child classes, leave it alone.
         /// </summary>
         /// <param name="materialEditor">material editor that uses this GUI.</param>
@@ -87,34 +98,32 @@ namespace VRLabs.SimpleShaderInspectors
             {
                 DefaultBgColor = GUI.backgroundColor;
                 _logo = EditorGUIUtility.isProSkin ? Styles.SSILogoDark : Styles.SSILogoLight;
-                //var stopWatch = new Stopwatch();
-                //stopWatch.Start();
-                HasNonAnimatableProperties = false;
+                NeedsNonAnimatableUpdate = false;
                 Controls = new List<SimpleControl>();
                 Materials = Array.ConvertAll(materialEditor.targets, item => (Material)item);
-                _shader = Materials[0].shader;
+                Shader = Materials[0].shader;
                 Start();
-                FetchOrGenerateLocalization();
-                ApplyPropertiesIndex(Controls, properties);
-                FetchProperties(Controls, properties);
+                LoadLocalizations();
+                Controls.SetInspector(this);
+                _nonAnimatablePropertyControls = (List<INonAnimatableProperty>)Controls.FindNonAnimatablePropertyControls();
+                Controls.FetchProperties(properties);
                 StartChecks(materialEditor);
                 _isFirstLoop = false;
                 if (Controls == null || Controls.Count == 0)
                 {
                     _doesContainControls = false;
                 }
-                //stopWatch.Stop();
-                //UnityEngine.Debug.Log(stopWatch.ElapsedMilliseconds);
+
             }
             else
             {
-                FetchProperties(Controls, properties);
+                Controls.FetchProperties(properties);
             }
-            //var stopWatch = new Stopwatch();
-            //stopWatch.Start();
+
             Header();
             DrawGUI(materialEditor, properties);
-            UpdateNonAnimatableProperties(materialEditor);
+            if (ContainsNonAnimatableProperties)
+                SSIHelper.UpdateNonAnimatableProperties(_nonAnimatablePropertyControls, materialEditor, NeedsNonAnimatableUpdate);
 
             // Draw footer and inspector logo.
             GUILayout.FlexibleSpace();
@@ -128,145 +137,56 @@ namespace VRLabs.SimpleShaderInspectors
             GUILayout.EndHorizontal();
 
             CheckChanges(materialEditor);
-            //stopWatch.Stop();
-            //UnityEngine.Debug.Log(stopWatch.ElapsedMilliseconds);
         }
 
         /// <summary>
-        /// Check changes happened to properties.
+        /// Load/reload the currently selected localization.
         /// </summary>
-        /// <param name="materialEditor">material editor that uses this GUI.</param>
-        protected virtual void CheckChanges(MaterialEditor materialEditor) { }
-        // Updates properties that should not be tracked while the animation tab is recording
-        private void UpdateNonAnimatableProperties(MaterialEditor materialEditor)
-        {
-            List<INonAnimatableProperty> nonAnimatableProperties = new List<INonAnimatableProperty>();
-            for (int i = 0; i < Controls.Count; i++)
-            {
-                if (Controls[i] is INonAnimatableProperty control)
-                {
-                    if (control.NonAnimatablePropertyChanged)
-                    {
-                        nonAnimatableProperties.Add(control);
-                    }
-                }
-            }
-
-            if (nonAnimatableProperties.Count == 0) return;
-            if (HasNonAnimatableProperties)
-            {
-                // Reflection bs to get which animation window is recording
-                System.Reflection.Assembly editorAssembly = typeof(Editor).Assembly;
-                System.Type windowType = editorAssembly.GetType("UnityEditorInternal.AnimationWindowState");
-
-                System.Reflection.PropertyInfo isRecordingProp = windowType.GetProperty
-                    ("recording", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
-
-                Object[] windowInstances = Resources.FindObjectsOfTypeAll(windowType);
-                Object recordingInstance = null;
-
-                for (int i = 0; i < windowInstances.Length; i++)
-                {
-                    bool isRecording = (bool)isRecordingProp.GetValue
-                        (windowInstances[i], null);
-
-                    if (isRecording)
-                    {
-                        recordingInstance = windowInstances[i];
-                        break;
-                    }
-                }
-                if (recordingInstance != null)
-                {
-                    System.Reflection.MethodBase stopRecording = windowType.GetMethod
-                    ("StopRecording", System.Reflection.BindingFlags.Instance |
-                                      System.Reflection.BindingFlags.Public);
-                    System.Reflection.MethodBase startRecording = windowType.GetMethod
-                    ("StartRecording", System.Reflection.BindingFlags.Instance |
-                                       System.Reflection.BindingFlags.Public);
-
-                    stopRecording?.Invoke(recordingInstance, null);
-                    SetNonAnimatableProperties(materialEditor, nonAnimatableProperties);
-                    startRecording?.Invoke(recordingInstance, null);
-                }
-                else
-                {
-                    SetNonAnimatableProperties(materialEditor, nonAnimatableProperties);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < nonAnimatableProperties.Count; i++)
-                {
-                    SetNonAnimatableProperties(materialEditor, nonAnimatableProperties);
-                }
-            }
-        }
-        // Retrieve localization information or creates a template one if it's missing.
-        // I really need to improve this mess one day.
-        private void FetchOrGenerateLocalization()
+        public void LoadLocalizations()
         {
             // Initializes path if it hasn't been initialized.
             if (string.IsNullOrWhiteSpace(_path))
             {
-                _path = AssetDatabase.GetAssetPath(_shader);
+                _path = AssetDatabase.GetAssetPath(Shader);
                 if (string.IsNullOrWhiteSpace(CustomLocalizationShaderName))
-                {
                     CustomLocalizationShaderName = Path.GetFileNameWithoutExtension(_path);
-                }
-                _path = Path.GetDirectoryName(_path) + "/Localization/" + CustomLocalizationShaderName;
+
+                _path = $"{Path.GetDirectoryName(_path)}/Localization/{CustomLocalizationShaderName}";
+
+                if (Directory.Exists(_path))
+                    Directory.CreateDirectory(_path);
             }
 
-            // Get Localization.
-            (_languages, _selectedLanguage, _selectedLanguageIndex) = Localization.GetLocalization(_path);
-
-            // Generates localization if null or retrieve it otherwise.
-            if (_languages == null)
+            // Get Localization.  
+            string settingsPath = $"{_path}/Settings.json";
+            if (File.Exists(settingsPath))
             {
-                (_languages, _selectedLanguage, _) = Localization.GenerateDefaultLocalization(Controls, _shader, _path);
-                _selectedLanguageIndex = 0;
+                _selectedLanguage = JsonUtility.FromJson<SettingsFile>(File.ReadAllText(settingsPath)).SelectedLanguage;
             }
-            SetLocalization();
-        }
-
-        // Retrieves the selected localization and applies it.
-        private void SetLocalization()
-        {
-            LocalizationFile localization = Localization.GetSelectedLocalization(_path, _selectedLanguage);
-            Localization.SaveSettings(_selectedLanguage, _path);
-            List<PropertyInfo> missingInfo = new List<PropertyInfo>();
-            SetPropertiesLocalization(Controls, localization, missingInfo);
-            if (missingInfo.Count > 0)
+            else
             {
-                Localization.AddDefaultsForMissingProperties(missingInfo, _selectedLanguage, _path);
+                File.WriteAllText(settingsPath, JsonUtility.ToJson(new SettingsFile { SelectedLanguage = "English" }));
+                _selectedLanguage = "English";
             }
-        }
 
-        // Applies a given localization to all controls recursively.
-        private void SetPropertiesLocalization(List<SimpleControl> controls, LocalizationFile localization, List<PropertyInfo> missingInfo)
-        {
-            foreach (SimpleControl control in controls)
+            Controls.ApplyLocalization($"{_path}/{_selectedLanguage}.json", true);
+
+            // Generate language options array based on available localizations.
+            List<string> names = new List<string>();
+            string[] localizations = Directory.GetFiles(_path);
+            for (int i = 0; i < localizations.Length; i++)
             {
-                control.Content = GetLocalizationContent(control, control.ControlAlias, localization, missingInfo);
-                switch (control)
+                if (localizations[i].EndsWith(".json", StringComparison.OrdinalIgnoreCase) && !localizations[i].EndsWith("Settings.json"))
                 {
-                    // Check if control has additional localization GUIContent to fill.
-                    case IAdditionalLocalization additional:
-                        {
-                            foreach (AdditionalLocalization content in additional.AdditionalContent)
-                            {
-                                string fullName = control.ControlAlias + "_" + content.Name;
-                                content.Content = GetLocalizationContent(control, fullName, localization, missingInfo);
-                            }
-
-                            break;
-                        }
-                    // Check if control has additional child controls.
-                    case IControlContainer container:
-                        SetPropertiesLocalization(container.Controls, localization, missingInfo);
-                        break;
+                    string name = Path.GetFileNameWithoutExtension(localizations[i]);
+                    names.Add(name);
+                    if (name.Equals(_selectedLanguage))
+                    {
+                        _selectedLanguageIndex = names.Count - 1;
+                    }
                 }
             }
+            _languages = names.ToArray();
         }
 
         // Draws the custom GUI.
@@ -284,7 +204,7 @@ namespace VRLabs.SimpleShaderInspectors
                     {
                         _selectedLanguageIndex = s;
                         _selectedLanguage = _languages[s];
-                        SetLocalization();
+                        Controls.ApplyLocalization($"{_path}/{_selectedLanguage}.json", true);
                     }
                     EditorGUILayout.EndHorizontal();
                     EditorGUILayout.Space();
@@ -292,53 +212,14 @@ namespace VRLabs.SimpleShaderInspectors
 
                 // Draw controls
                 foreach (SimpleControl control in Controls)
-                {
                     control.DrawControl(materialEditor);
-                }
             }
             else
             {
-                // Literally the only non localizable thing in the entire inspector. not sure if i want to do something about it.
-                // In a working inspector it should never appear to begin with.
+                // In a working inspector it should never appear.
                 EditorGUILayout.HelpBox("No controls have been passed to the Start() method, therefore a default inspector has been drawn, if you are an end user of the shader try to reinstall the shader or contact the creator.", MessageType.Error);
                 base.OnGUI(materialEditor, properties);
             }
-        }
-
-        // Gets the GUIContent of selected controls.
-        private GUIContent GetLocalizationContent(SimpleControl control, string fullName, LocalizationFile localization, List<PropertyInfo> missingInfo)
-        {
-            PropertyInfo info = null;
-            for (int i = 0; i < localization.Properties.Length; i++)
-            {
-                if (localization.Properties[i].Name.Equals(fullName))
-                {
-                    info = localization.Properties[i];
-                    break;
-                }
-            }
-
-            if (info != null) return new GUIContent(info.DisplayName, info.Tooltip);
-            string displayName;
-            if (control is PropertyControl pr)
-            {
-                displayName = Localization.GetPropertyDescription(pr.PropertyName, _shader);
-            }
-            else
-            {
-                displayName = Localization.GetPropertyDescription(control.ControlAlias, _shader);
-            }
-            info = new PropertyInfo
-            {
-                Name = fullName,
-                DisplayName = displayName,
-                Tooltip = displayName
-            };
-            if (!string.IsNullOrEmpty(fullName))
-            {
-                missingInfo.Add(info);
-            }
-            return new GUIContent(info.DisplayName, info.Tooltip);
         }
 
         // Draws the SSI logo
@@ -350,261 +231,5 @@ namespace VRLabs.SimpleShaderInspectors
             }
         }
 
-        // Caches all properties indexes used in the shader.
-        private static void ApplyPropertiesIndex(List<SimpleControl> controls, MaterialProperty[] properties)
-        {
-            for (int i = 0; i < controls.Count; i++)
-            {
-                if (controls[i] is PropertyControl pr)
-                {
-                    pr.SetPropertyIndex(properties);
-                }
-
-                if (controls[i] is IAdditionalProperties add)
-                {
-                    for (int j = 0; j < add.AdditionalProperties.Length; j++)
-                    {
-                        add.AdditionalProperties[j].SetPropertyIndex(properties);
-                    }
-                }
-
-                if (controls[i] is IControlContainer con)
-                {
-                    ApplyPropertiesIndex(con.Controls, properties);
-                }
-            }
-        }
-
-        // Fetches all properties from the currently given properties array.
-        private static void FetchProperties(List<SimpleControl> controls, MaterialProperty[] properties)
-        {
-            for (int i = 0; i < controls.Count; i++)
-            {
-                if (controls[i] is PropertyControl pr)
-                {
-                    pr.FetchProperty(properties);
-                }
-
-                if (controls[i] is IAdditionalProperties add)
-                {
-                    for (int j = 0; j < add.AdditionalProperties.Length; j++)
-                    {
-                        add.AdditionalProperties[j].FetchProperty(properties);
-                    }
-                }
-
-                if (controls[i] is IControlContainer con)
-                {
-                    FetchProperties(con.Controls, properties);
-                }
-            }
-        }
-
-        private static void SetNonAnimatableProperties(MaterialEditor materialEditor, List<INonAnimatableProperty> nonAnimatableProperties)
-        {
-            for (int i = 0; i < nonAnimatableProperties.Count; i++)
-            {
-                nonAnimatableProperties[i].UpdateNonAnimatableProperty(materialEditor);
-                nonAnimatableProperties[i].NonAnimatablePropertyChanged = false;
-            }
-        }
-
-        /// <summary>
-        /// Find a material property from its name.
-        /// </summary>
-        /// <param name="propertyName">Name of the material proeperty.</param>
-        /// <param name="properties">Array of material properties to search from.</param>
-        /// <param name="propertyIsMandatory">Boolean indicating if it's mandatory to find the requested material property</param>
-        /// <returns>The material property with the wanted name.</returns>
-        internal static int FindPropertyIndex(string propertyName, MaterialProperty[] properties, bool propertyIsMandatory = false)
-        {
-            for (int i = 0; i < properties.Length; i++)
-            {
-                if (properties[i] != null && properties[i].name == propertyName)
-                    return i;
-            }
-
-            // We assume all required properties can be found, otherwise something is broken.
-            if (propertyIsMandatory)
-                throw new ArgumentException("Could not find MaterialProperty: '" + propertyName + "', Num properties: " + properties.Length);
-            return -1;
-        }
-
-        /// <summary>
-        /// Get a path to save a texture relative to the material.
-        /// </summary>
-        /// <param name="mat">Material.</param>
-        /// <param name="name">Name of the texture.</param>
-        /// <returns>A path for the texture to save.</returns>
-        public static string GetTextureDestinationPath(Material mat, string name)
-        {
-            string path = AssetDatabase.GetAssetPath(mat);
-            path = Directory.GetParent(path).FullName;
-            string pathParent = Directory.GetParent(path).FullName;
-            if (Directory.Exists(pathParent + "/Textures/"))
-            {
-                return pathParent + "/Textures/" + mat.name + name;
-            }
-            else
-            {
-                return path + "/" + mat.name + name;
-            }
-        }
-
-        /// <summary>
-        /// Saves a texture to a specified path.
-        /// </summary>
-        /// <param name="texture">Texture to save.</param>
-        /// <param name="path">path where you want to save the texture.</param>
-        /// <param name="mode">Texture wrap mode (default: Repeat).</param>
-        public static void SaveTexture(Texture2D texture, string path, TextureWrapMode mode = TextureWrapMode.Repeat)
-        {
-            byte[] bytes = texture.EncodeToPNG();
-
-            System.IO.File.WriteAllBytes(path, bytes);
-            AssetDatabase.Refresh();
-            path = path.Substring(path.LastIndexOf("Assets"));
-            TextureImporter t = AssetImporter.GetAtPath(path) as TextureImporter;
-            t.wrapMode = mode;
-            t.isReadable = true;
-            AssetDatabase.ImportAsset(path);
-        }
-
-        /// <summary>
-        /// Saves a texture to a specified path, and returns a reference of the new asset.
-        /// </summary>
-        /// <param name="texture">Texture to save.</param>
-        /// <param name="path">path where you want to save the texture.</param>
-        /// <param name="mode">Texture wrap mode (default: Repeat).</param>
-        /// <returns>A Texture2D that references the newly created asset.</returns>
-        public static Texture2D SaveAndGetTexture(Texture2D texture, string path, TextureWrapMode mode = TextureWrapMode.Repeat)
-        {
-            SaveTexture(texture, path, mode);
-            path = path.Substring(path.LastIndexOf("Assets"));
-            return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
-        }
-
-        /// <summary>
-        /// Set the texture readable state.
-        /// </summary>
-        /// <param name="texture">Texture</param>
-        /// <param name="isReadable">Does the texture need to be readable.</param>
-        public static void SetTextureImporterReadable(Texture2D texture, bool isReadable)
-        {
-            if (texture == null) return;
-
-            string assetPath = AssetDatabase.GetAssetPath(texture);
-            var tImporter = AssetImporter.GetAtPath(assetPath) as TextureImporter;
-            if (tImporter != null)
-            {
-                tImporter.textureType = TextureImporterType.Default;
-                tImporter.isReadable = isReadable;
-                AssetDatabase.ImportAsset(assetPath);
-                //AssetDatabase.Refresh();
-            }
-        }
-
-        public static void SetTextureImporterAlpha(Texture2D texture, bool alphaIsTransparency)
-        {
-            if (texture == null) return;
-
-            string assetPath = AssetDatabase.GetAssetPath(texture);
-            var tImporter = AssetImporter.GetAtPath(assetPath) as TextureImporter;
-            if (tImporter != null)
-            {
-                tImporter.textureType = TextureImporterType.Default;
-                tImporter.alphaIsTransparency = alphaIsTransparency;
-                AssetDatabase.ImportAsset(assetPath);
-            }
-        }
-    }
-
-    /// <summary>
-    /// This class contains extension methods that are meant to be used inside a SimpleShaderInspector child class.
-    /// </summary>
-    public static class SSIExtensions
-    {
-        /// <summary>
-        /// Sets a keyword state to all materials in the array.
-        /// </summary>
-        /// <param name="materials">Material array this method extends to.</param>
-        /// <param name="keyword">The keyword that is being toggled.</param>
-        /// <param name="state">Toggle value.</param>
-        public static void SetKeyword(this Material[] materials, string keyword, bool state)
-        {
-            foreach (var m in materials)
-            {
-                if (state)
-                    m.EnableKeyword(keyword);
-                else
-                    m.DisableKeyword(keyword);
-            }
-        }
-
-        /// <summary>
-        /// Gets the mixed value state of a keyword on the materials array
-        /// </summary>
-        /// <param name="materials">Material array this method extends to.</param>
-        /// <param name="keyword">The keyword to check against.</param>
-        /// <returns>True if the keyword has mixed values, false otherwise.</returns>
-        public static bool IsKeywordMixedValue(this Material[] materials, string keyword)
-        {
-            bool reference = materials[0].IsKeywordEnabled(keyword);
-            foreach (var m in materials)
-            {
-                if (m.IsKeywordEnabled(keyword) != reference)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Set override tag to all materials in the array.
-        /// </summary>
-        /// <param name="materials">Material array this method extends to.</param>
-        /// <param name="tagName">Name of the tag.</param>
-        /// <param name="value">Value of the tag.</param>
-        public static void SetOverrideTag(this Material[] materials, string tagName, string value)
-        {
-            foreach (var m in materials)
-                m.SetOverrideTag(tagName, value);
-        }
-
-        /// <summary>
-        /// Set int to all materials in the array.
-        /// </summary>
-        /// <param name="materials">Material array this method extends to.</param>
-        /// <param name="name">Name of the int.</param>
-        /// <param name="value">Value of the int.</param>
-        public static void SetInt(this Material[] materials, string name, int value)
-        {
-            foreach (var m in materials)
-                m.SetInt(name, value);
-        }
-
-        /// <summary>
-        /// Set vector to all materials in the array.
-        /// </summary>
-        /// <param name="materials">Material array this method extends to.</param>
-        /// <param name="name">Name of the Vector4.</param>
-        /// <param name="value">Value of the Vector4.</param>
-        public static void SetVector(this Material[] materials, string name, Vector4 value)
-        {
-            foreach (var m in materials)
-                m.SetVector(name, value);
-        }
-
-        /// <summary>
-        /// Set render queue to all materials in the array.
-        /// </summary>
-        /// <param name="materials">Material array this method extends to.</param>
-        /// <param name="queue">Render queue value.</param>
-        public static void SetRenderQueue(this Material[] materials, int queue)
-        {
-            foreach (var m in materials)
-                m.renderQueue = queue;
-        }
     }
 }


### PR DESCRIPTION
This pr aims to separate behaviours currently happening inside the SimpleShaderInspector class.

In particular a lot of functions that are not required to be inside the SimpleShaderInspector class have been moved away, mainly to the SSIHelper class.

This makes possible to introduce a ISimpleShaderInspector interface that can be used whenever a user wants to make its own inspector without relying on the provided base class, but still having the ability to use single functions that were previously contained inside the SimpleShaderInspector class. Controls are now also able to access a ISimpleShaderInspector property that should contain the inspector they are displayed on, granted the inspector implementation takes care of setting that property in its controls during initialization.

This also needed a small rework of the localization system in order to make people able to use it in their own inspector implementations.