### PR TITLE
Set a default Section Alias

### DIFF
--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -103,6 +103,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         {
             InitSection();
             useDictionary = true;
+            ControlAlias = "Section";
             hideValue = 0;
             showValue = 1;
         }


### PR DESCRIPTION
Set a default Section Alias for Section controls so they do not get ignored by the localization system