### PR TITLE
Add Action for automatic release on tag creation

### DIFF
--- a/.github/release-notes.configuration.json
+++ b/.github/release-notes.configuration.json
@@ -1,0 +1,63 @@
+{
+    "categories": [
+        {
+            "title": "## New",
+            "labels": [
+                "new feature",
+                "new control"
+            ]
+        },
+        {
+            "title": "## Changed",
+            "labels": [
+                "feature enhancement",
+                "control enhancement"
+            ]
+        },
+        {
+            "title": "## Fixed",
+            "labels": [
+                "bugfix"
+            ]
+        },
+        {
+            "title": "## Breaking Changes",
+            "labels": [
+                "breaking change"
+            ]
+        }
+    ],
+    "ignore_labels": [
+        "ignore"
+    ],
+    "sort": "ASC",
+    "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
+    "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+    "empty_template": "- no changes",
+    "label_extractor": [
+        {
+            "pattern": "(.) (.+)",
+            "target": "$1"
+        },
+        {
+            "pattern": "(.) (.+)",
+            "target": "$1",
+            "on_property": "title"
+        }
+    ],
+    "transformers": [
+        {
+            "pattern": "[\\-\\*] (\\[(...|TEST|CI|SKIP)\\])( )?(.+?)\n(.+?[\\-\\*] )(.+)",
+            "target": "- $4\n  - $6"
+        }
+    ],
+    "max_tags_to_fetch": 200,
+    "max_pull_requests": 200,
+    "max_back_track_time_days": 365,
+    "exclude_merge_branches": [
+        "Owner/qa"
+    ],
+    "tag_resolver": {
+        "method": "semver"
+    }
+}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,79 @@
+name: create-release
+on:
+  push: 
+    tags:
+      - "v*"
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Branch name
+        id: branch_name
+        run: |
+          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
+          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
+          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+      - name: Prepare Folder For Packaging
+        run: |
+          mkdir -p "Assets/VRLabs/SimpleShaderInspectors"
+          ls | grep -v "Assets" | xargs mv -t "Assets/VRLabs/SimpleShaderInspectors"
+          echo "Assets/VRLabs.meta" > ssiFullPackage
+          echo "Assets/VRLabs/SimpleShaderInspectors.meta" >> ssiFullPackage
+          echo -e "fileFormatVersion: 2\nguid: 652a1ba5b00554143bc9a76307dbc4e8\nfolderAsset: yes\nDefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: " > "Assets/VRLabs.meta"
+          echo -e "fileFormatVersion: 2\nguid: 2b0f20ac9e1e9fa4aa1cdad44282be45\nfolderAsset: yes\nDefaultImporter:\n  externalObjects: {}\n  userData: \n  assetBundleName: \n  assetBundleVariant: " > "Assets/VRLabs/SimpleShaderInspectors.meta"
+          find "Assets/VRLabs/SimpleShaderInspectors/" -name \*.meta >> ssiFullPackage
+          grep -v "Assets/VRLabs/SimpleShaderInspectors/Editor/Tools\|Assets/VRLabs/SimpleShaderInspectors/Examples" < ssiFullPackage > ssiBasePackage
+          grep -v "Assets/VRLabs/SimpleShaderInspectors/Examples" < ssiFullPackage > ssiDevPackage
+          grep 'Assets/VRLabs/SimpleShaderInspectors/Examples' < ssiFullPackage > ssiExamplesPackage
+          echo "Assets/VRLabs.meta" >> ssiExamplesPackage
+          echo "Assets/VRLabs/SimpleShaderInspectors.meta" >> ssiExamplesPackage
+
+      - name: Create Base UnityPackage
+        env:
+          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
+        uses: pCYSl5EDgo/create-unitypackage@master
+        with:
+          package-path: 'Simple.Shader.Inspectors.${{ env.SOURCE_TAG }}.unitypackage'
+          include-files: ssiBasePackage
+
+      - name: Create Dev UnityPackage
+        env:
+          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
+        uses: pCYSl5EDgo/create-unitypackage@master
+        with:
+          package-path: 'Simple.Shader.Inspectors.Dev.${{ env.SOURCE_TAG }}.unitypackage'
+          include-files: ssiDevPackage
+
+      - name: Create Examples UnityPackage
+        env:
+          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
+        uses: pCYSl5EDgo/create-unitypackage@master
+        with:
+          package-path: 'Simple.Shader.Inspectors.Examples.${{ env.SOURCE_TAG }}.unitypackage'
+          include-files: ssiExamplesPackage
+      
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v1
+        with:
+          configuration: ".github/release-notes-configuration.json"
+          outputFile: "releaseNotes.txt"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: "Simple Shader Inspectors ${{ env.SOURCE_TAG }}"
+          body_path: "releaseNotes.txt"
+          files: |
+            Simple.Shader.Inspectors.${{ env.SOURCE_TAG }}.unitypackage
+            Simple.Shader.Inspectors.Dev.${{ env.SOURCE_TAG }}.unitypackage
+            Simple.Shader.Inspectors.Examples.${{ env.SOURCE_TAG }}.unitypackage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}


### PR DESCRIPTION
The added action automatically generates a release and relative unitypackage files whenever a new version tag is added (any tag that starts with "v").

This makes way less annoying to deploy new releases of the library, 

Also it automatically generates a release note based on pull requests.