### PR TITLE
Update Artifacts

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,7 +24,7 @@ jobs:
           docfx docsOutput/docs/docfx.json
           
       - name: Upload Site Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: site
           path: docsOutput/docs/_site
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
     
       - name: Download Artifacts 
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: site
 


### PR DESCRIPTION
Artifacts v1 does not accept the retention days parameter, and we don't want to keep around exported files from the action since they're only used to push to gh-pages, thus not needed after the action has run