### PR TITLE
Fixed some bugs with the localization

### DIFF
--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -11,7 +11,7 @@ namespace VRLabs.SimpleShaderInspectors
     /// <summary>
     /// Static helper class used for managing localizations.
     /// </summary>
-    internal static class Localization
+    public static class Localization
     {
         /// <summary>
         /// Apply Localization strings to a list of controls.
@@ -93,7 +93,7 @@ namespace VRLabs.SimpleShaderInspectors
         }
     }
 
-    internal static class LocalizationSearchers
+    public static class LocalizationSearchers
     {
         public static PropertyInfo FindPropertyByName(this IEnumerable<PropertyInfo> properties, string name)
         {
@@ -120,19 +120,19 @@ namespace VRLabs.SimpleShaderInspectors
     }
 
     [Serializable]
-    internal class PropertyInfo
+    public class PropertyInfo
     {
         public string Name;
         public string DisplayName;
         public string Tooltip;
     }
     [Serializable]
-    internal class LocalizationFile
+    public class LocalizationFile
     {
         public PropertyInfo[] Properties;
     }
     [Serializable]
-    internal class SettingsFile
+    public class SettingsFile
     {
         public string SelectedLanguage;
     }

--- a/Editor/SimpleShaderInspector.cs
+++ b/Editor/SimpleShaderInspector.cs
@@ -191,7 +191,7 @@ namespace VRLabs.SimpleShaderInspectors
 
                 _path = $"{Path.GetDirectoryName(_path)}/Localization/{CustomLocalizationShaderName}";
 
-                if (Directory.Exists(_path))
+                if (!Directory.Exists(_path))
                     Directory.CreateDirectory(_path);
             }
 


### PR DESCRIPTION
For some reason the localization class was internal when there are benefits in keeping it public.

Also the inspector would give out exceptions when the localization folder was not available due to a flipped bool