### PR TITLE
Set specific version of docfx to install

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build DocFX
         run: |
-          choco install docfx -y
+          choco install docfx -y --version 2.56.7
           docfx docsOutput/docs/docfx.json
           
       - name: Upload Site Artifacts


### PR DESCRIPTION
Apparently building with DocFX breaks due to plugins not working right with the newer version of DocFX, so i updated the action to use a specific version instead of the latest one.