### PR TITLE
Localization fixes

### DIFF
--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -97,15 +97,7 @@ namespace VRLabs.SimpleShaderInspectors
     {
         public static PropertyInfo FindPropertyByName(this IEnumerable<PropertyInfo> properties, string name)
         {
-            if (properties == null) return null;
-            foreach (var property in properties)
-            {
-                if (property.Name.Equals(name))
-                {
-                    return property;
-                }
-            }
-            return null;
+            return properties?.FirstOrDefault(property => property.Name.Equals(name));
         }
         public static string FindPropertyByName(this (string, string)[] properties, string name)
         {

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -97,6 +97,7 @@ namespace VRLabs.SimpleShaderInspectors
     {
         public static PropertyInfo FindPropertyByName(this IEnumerable<PropertyInfo> properties, string name)
         {
+            if (properties == null) return null;
             foreach (var property in properties)
             {
                 if (property.Name.Equals(name))
@@ -130,6 +131,11 @@ namespace VRLabs.SimpleShaderInspectors
     public class LocalizationFile
     {
         public PropertyInfo[] Properties;
+        
+        public LocalizationFile()
+        {
+            Properties = Array.Empty<PropertyInfo>();
+        }
     }
     [Serializable]
     public class SettingsFile


### PR DESCRIPTION
In some cases (like when trying to do iterations) an exception would appear due to the `Properties` array not being initialized.

With this change the array is initialized as an empty array.