### PR TITLE
Updated Ordered Sections to use persistent dictionaries for remembering position.

### DIFF
--- a/.docs/guides/InspectorDevelopment/Sections.md
+++ b/.docs/guides/InspectorDevelopment/Sections.md
@@ -43,10 +43,10 @@ Currently this section does not have chainable methods on top of what is already
 ## OrderedSection
 
 ```csharp
-   AddOrderedSection(string activatePropertyName);
+   AddOrderedSection(string activatePropertyName, float enableValue = 1, float disableValue = 0);
 ```
 
-This type of section could be interpreted as a different implementation of `ActivatableSection` since it works similarly on the surfaace, but there's one problem, you *can't* create it with the usual `this.AddOrderedSection` this time.
+This type of section could be interpreted as a different implementation of `ActivatableSection` since it works similarly on the surface, but there's one problem, you *can't* create it with the usual `this.AddOrderedSection` this time.
 
 >[!CAUTION]
 >You could create a new `OrderedSection` using its default constructor, but you should not do that. You would not get a working section out of that anyways.

--- a/Editor/Autogenerated/VRLabs.SimpleShaderInspectors.Controls.Sections.Chainables.cs
+++ b/Editor/Autogenerated/VRLabs.SimpleShaderInspectors.Controls.Sections.Chainables.cs
@@ -15,15 +15,15 @@
             return control;
         }
 
-        public static OrderedSection AddOrderedSection(this OrderedSectionGroup container, System.String activatePropertyName, System.String showPropertyName, System.Single hideValue = 0, System.Single showValue = 1)
+        public static OrderedSection AddOrderedSection(this OrderedSectionGroup container, System.String activatePropertyName, System.String showPropertyName, System.Single enableValue = 1, System.Single disableValue = 0, System.Single showValue = 1, System.Single hideValue = 0)
         {
-            var control = new OrderedSection(activatePropertyName, showPropertyName, hideValue, showValue);
+            var control = new OrderedSection(activatePropertyName, showPropertyName, enableValue, disableValue, showValue, hideValue);
             container.AddControl(control);
             return control;
         }
-        public static OrderedSection AddOrderedSection(this OrderedSectionGroup container, System.String activatePropertyName)
+        public static OrderedSection AddOrderedSection(this OrderedSectionGroup container, System.String activatePropertyName, System.Single enableValue = 1, System.Single disableValue = 0)
         {
-            var control = new OrderedSection(activatePropertyName);
+            var control = new OrderedSection(activatePropertyName, enableValue, disableValue);
             container.AddControl(control);
             return control;
         }

--- a/Editor/Controls/Sections/OrderedSection.cs
+++ b/Editor/Controls/Sections/OrderedSection.cs
@@ -20,8 +20,6 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
     /// </para>
     /// <para>
     /// Another quirk of this type of section is that it can be moved up or down relative to the sections of the same group, letting the user order them in whichever way they see fit best.
-    /// As a result of this behaviour the value the property driving the enabled state will be 0 when not enabled, or the ordering index of the section when enabled, meaning that when
-    /// enabled the material property can have any value > 0.
     /// </para>
     /// </remarks>
     /// <example>
@@ -32,13 +30,18 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
     ///
     /// // Adds an OrderedSection using the specified property as activation property
     /// group.AddOrderedSection("_ActivateProperty");  
+    /// 
+    ///  // Adds an OrderedSection using the specified property as activation property,
+    ///  // the values for activation are set to 2-3 respectively when disabled and enabled
+    /// group.AddOrderedSection("_ActivateProperty", 2, 3); 
     ///
     /// // Adds an OrderedSection using the specified properties for activation and folding state
     /// group.AddOrderedSection("_ActivateProperty", "_ShowProperty"); 
     ///
     /// // Adds an OrderedSection using the specified properties for activation and folding state,
-    /// // the values for folding are set to 2/3 respectively when disabled and enabled
-    /// group.AddOrderedSection("_ActivateProperty", "_ShowProperty", 2, 3); 
+    /// // the values for activation are set to 2-3 respectively when disabled and enabled
+    /// // the values for folding are set to 4-6 respectively when folded in and out
+    /// group.AddOrderedSection("_ActivateProperty", "_ShowProperty", 2, 3, 4, 6); 
     /// </code>
     /// </example>
     public class OrderedSection : Section, IAdditionalProperties
@@ -181,11 +184,13 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// </summary>
         /// <param name="activatePropertyName">Material property that will drive the section enable state</param>
         /// <param name="showPropertyName">Material property that will drive the section open state</param>
-        /// <param name="hideValue">Float value that the material property will have if the section is collapsed, optional (default: 0).</param>
         /// <param name="showValue">Float value that the material property will have if the section is visible, optional (default: 1).</param>
+        /// <param name="hideValue">Float value that the material property will have if the section is collapsed, optional (default: 0).</param>
+        /// <param name="enableValue">Float value that the material property will have if the section is enabled, optional (default: 1).</param>
+        /// <param name="disableValue">Float value that the material property will have if the section is disabled, optional (default: 0).</param>
         [LimitAccessScope(typeof(OrderedSectionGroup))]
         public OrderedSection(string activatePropertyName, string showPropertyName, float enableValue = 1,
-            float disableValue = 0, float hideValue = 0, float showValue = 1) : base(showPropertyName, hideValue, showValue)
+            float disableValue = 0, float showValue = 1, float hideValue = 0) : base(showPropertyName, hideValue, showValue)
         {
             AdditionalProperties = new AdditionalProperty[1];
             AdditionalProperties[0] = new AdditionalProperty(activatePropertyName);
@@ -205,6 +210,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// Default constructor of <see cref="OrderedSection"/>.
         /// </summary>
         /// <param name="activatePropertyName">Material property that will drive the section enable state</param>
+        /// <param name="enableValue">Float value that the material property will have if the section is enabled, optional (default: 1).</param>
+        /// <param name="disableValue">Float value that the material property will have if the section is disabled, optional (default: 0).</param>
         [LimitAccessScope(typeof(OrderedSectionGroup))]
         public OrderedSection(string activatePropertyName, float enableValue = 1, float disableValue = 0) : base()
         {
@@ -225,7 +232,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         }
 
         /// <summary>
-        /// Draws and hanles the up, down and delete icon on the side.
+        /// Draws and handles the up, down and delete icon on the side.
         /// </summary>
         protected void DrawSideButtons()
         {

--- a/Editor/Controls/Sections/OrderedSectionGroup.cs
+++ b/Editor/Controls/Sections/OrderedSectionGroup.cs
@@ -83,13 +83,13 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
                 {
                     if (Controls[i].PushState == 1 && i < Controls.Count - 1)
                     {
-                        Controls[i].AdditionalProperties[0].Property.floatValue++;
-                        Controls[i + 1].AdditionalProperties[0].Property.floatValue--;
+                        Controls[i].SectionPosition++;
+                        Controls[i + 1].SectionPosition--;
                     }
                     else if (Controls[i].PushState == -1 && i > 0 && Controls[i - 1].Enabled)
                     {
-                        Controls[i].AdditionalProperties[0].Property.floatValue--;
-                        Controls[i - 1].AdditionalProperties[0].Property.floatValue++;
+                        Controls[i].SectionPosition--;
+                        Controls[i - 1].SectionPosition++;
                     }
                     Controls[i].PushState = 0;
                     needsOrderUpdate = true;
@@ -135,7 +135,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         private void TurnOnSection(object sectionVariable)
         {
             var section = (OrderedSection)sectionVariable;
-            section.AdditionalProperties[0].Property.floatValue = 753;
+            section.SectionPosition = 753;
             section.HasSectionTurnedOn = true;
             _areNewSectionsAvailable = AreNewSectionsAvailable();
             UpdateSectionsOrder();
@@ -147,9 +147,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             int j = 1;
             foreach (var section in Controls)
             {
-                if (section.AdditionalProperties[0].Property.floatValue != 0 && !section.AdditionalProperties[0].Property.hasMixedValue)
+                if (section.SectionPosition != 0 && !section.AdditionalProperties[0].Property.hasMixedValue)
                 {
-                    section.AdditionalProperties[0].Property.floatValue = j;
+                    section.SectionPosition = j;
                     j++;
                 }
             }
@@ -188,9 +188,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             if (x == null) return y == null ? 0 : -1;
 
             if (y == null) return 1;
-            if (x.AdditionalProperties[0].Property.floatValue > y.AdditionalProperties[0].Property.floatValue)
+            if (x.SectionPosition > y.SectionPosition)
                 return 1;
-            if (x.AdditionalProperties[0].Property.floatValue < y.AdditionalProperties[0].Property.floatValue)
+            if (x.SectionPosition < y.SectionPosition)
                 return -1;
             return 0;
         }

--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -204,7 +204,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
                 if (!firstCycle) return;
                 
                 if (dictionaryKey == null)
-                    dictionaryKey = ControlAlias + ((Material)materialEditor.target).GetInstanceID();
+                    dictionaryKey = ControlAlias +  AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(materialEditor.target));
                 
                 if (StaticDictionaries.BoolDictionary.TryGetValue(dictionaryKey, out bool show))
                 {
@@ -213,7 +213,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
                 else
                 {
                     Show = false;
-                    StaticDictionaries.BoolDictionary[dictionaryKey] = Show;
+                    StaticDictionaries.BoolDictionary.SetValue(dictionaryKey, Show);
                 }
                 firstCycle = false;
             }
@@ -236,7 +236,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         {
             if (useDictionary)
             {
-                StaticDictionaries.BoolDictionary[dictionaryKey] = Show;
+                StaticDictionaries.BoolDictionary.SetValue(dictionaryKey, Show);
             }
             else
             {

--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -203,8 +203,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             {
                 if (!firstCycle) return;
                 
-                if (dictionaryKey == null)
-                    dictionaryKey = ControlAlias +  AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(materialEditor.target));
+                if (string.IsNullOrWhiteSpace(dictionaryKey))
+                    dictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_Show";
                 
                 if (StaticDictionaries.BoolDictionary.TryGetValue(dictionaryKey, out bool show))
                 {

--- a/Editor/Resources/Dictionaries.meta
+++ b/Editor/Resources/Dictionaries.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c141f07f2e5265943b947c1343b93051
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Resources/Dictionaries/SSIDictionaries.asset
+++ b/Editor/Resources/Dictionaries/SSIDictionaries.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45db28035fecfe5408f3b903a531b7fd, type: 3}
+  m_Name: SSIDictionaries
+  m_EditorClassIdentifier: 
+  boolDictionary: []
+  intDictionary: []

--- a/Editor/Resources/Dictionaries/SSIDictionaries.asset.meta
+++ b/Editor/Resources/Dictionaries/SSIDictionaries.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc2c13316478301439762e8598fe180a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/SerializedDictionaries.cs
+++ b/Editor/SerializedDictionaries.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEditor;
+using System;
+using System.Collections.Generic;
+
+namespace VRLabs.SimpleShaderInspectors
+{
+    /// <summary>
+    /// Class used to save the dictionaries used by the API
+    /// </summary>
+    /// <remarks>
+    /// The API provides dictionaries to store data by identifier up to 30 days, those dictionaries are automatically saved into this asset.
+    /// </remarks>
+    public class SerializedDictionaries : ScriptableObject
+    {
+        [Serializable]
+        public struct BoolItem
+        {
+            public string key;
+            public bool value;
+            public long date;
+        }
+
+        [Serializable]
+        public struct IntItem
+        {
+            public string key;
+            public int value;
+            public long date;
+        }
+
+        /// <summary>
+        /// list for the bool dictionary
+        /// </summary>
+        public List<BoolItem> boolDictionary;
+        public List<IntItem> intDictionary;
+
+        public SerializedDictionaries()
+        {
+            boolDictionary = new List<BoolItem>();
+            intDictionary = new List<IntItem>();
+        }
+
+        public void SetBoolDictionary(List<(string, bool, DateTime)> list)
+        {
+            boolDictionary.Clear();
+            foreach(var item in list)
+                boolDictionary.Add(new BoolItem{key=item.Item1, value=item.Item2, date=item.Item3.ToBinary()});
+        }
+
+        public void SetIntDictionary(List<(string, int, DateTime)> list)
+        {
+            intDictionary.Clear();
+            foreach(var item in list)
+                intDictionary.Add(new IntItem{key=item.Item1, value=item.Item2, date=item.Item3.ToBinary()});
+        }
+    }
+}

--- a/Editor/SerializedDictionaries.cs.meta
+++ b/Editor/SerializedDictionaries.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45db28035fecfe5408f3b903a531b7fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/StaticDictionaries.cs
+++ b/Editor/StaticDictionaries.cs
@@ -1,4 +1,8 @@
+using System;
+using System.IO;
 using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
 
 namespace VRLabs.SimpleShaderInspectors
 {
@@ -7,9 +11,73 @@ namespace VRLabs.SimpleShaderInspectors
     /// </summary>
     public static class StaticDictionaries
     {
+        private static SerializedDictionaries _dictionaries;
+        private static TimedDictionary<string, bool> _boolDictionary;
         /// <summary>
         /// Dictionary containing boolean values.
         /// </summary>
-        public static Dictionary<string, bool> BoolDictionary { get; set; } = new Dictionary<string, bool>();
+        public static TimedDictionary<string, bool> BoolDictionary 
+        { 
+            get 
+            {
+                if(_boolDictionary != null) return _boolDictionary;
+                LoadDictionaries();
+                return _boolDictionary;
+
+            }
+        }
+
+        private static TimedDictionary<string, int> _intDictionary;
+        /// <summary>
+        /// Dictionary containing integer values.
+        /// </summary>
+        public static TimedDictionary<string, int> IntDictionary 
+        { 
+            get 
+            {
+                if(_intDictionary != null) return _intDictionary;
+                LoadDictionaries();
+                return _intDictionary;
+            }
+        }
+        
+        private static void LoadDictionaries()
+        {
+            _dictionaries = Resources.Load<SerializedDictionaries>("Dictionaries/SSIDictionaries");
+
+            if(_dictionaries == null)
+            {
+                _dictionaries = ScriptableObject.CreateInstance<SerializedDictionaries>();
+                Directory.CreateDirectory("Assets/Resources/Dictionaries");
+                AssetDatabase.CreateAsset(_dictionaries,"Assets/Resources/Dictionaries/SSIDictionaries.asset");
+                AssetDatabase.SaveAssets();
+            }
+
+            _boolDictionary = new TimedDictionary<string, bool>();
+            foreach(SerializedDictionaries.BoolItem item in _dictionaries.boolDictionary)
+                _boolDictionary.SetValue(item.key, item.value, DateTime.FromBinary(item.date));
+
+             _intDictionary = new TimedDictionary<string, int>();
+            foreach(SerializedDictionaries.IntItem item in _dictionaries.intDictionary)
+                _intDictionary.SetValue(item.key, item.value, DateTime.FromBinary(item.date));
+        }
+
+        [InitializeOnLoad]
+        public class Startup
+        {
+            static Startup() => EditorApplication.quitting += SaveAsset;
+
+            private static void SaveAsset()
+            {
+                if(_dictionaries != null) 
+                {
+                    StaticDictionaries.BoolDictionary.ClearOld();
+                    StaticDictionaries.IntDictionary.ClearOld();
+                    _dictionaries.SetBoolDictionary(StaticDictionaries.BoolDictionary.GetSerializedDictionary());
+                    _dictionaries.SetIntDictionary(StaticDictionaries.IntDictionary.GetSerializedDictionary());
+                    EditorUtility.SetDirty(_dictionaries);
+                }
+            }
+        }
     }
 }

--- a/Editor/TimedDictionary.cs
+++ b/Editor/TimedDictionary.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+
+namespace VRLabs.SimpleShaderInspectors
+{
+    /// <summary>
+    /// Class used to identify a dictionary that also contains the date of last edit.
+    /// </summary>
+    /// <typeparam name="TKey">Type of the key</typeparam>
+    /// <typeparam name="TValue">Type of the value</typeparam>
+    public class TimedDictionary<TKey, TValue>
+    {
+        private Dictionary<TKey, (DateTime, TValue)> _dictionary;
+
+        /// <summary>
+        /// Keys stored in the dictionary
+        /// </summary>
+        public  Dictionary<TKey, (DateTime, TValue)>.KeyCollection Keys => _dictionary.Keys;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public TimedDictionary()
+        {
+            _dictionary = new Dictionary<TKey, (DateTime, TValue)>();
+        }
+
+        /// <summary>
+        /// Try to get the value with the specified key
+        /// </summary>
+        /// <param name="key">Key to get the value from</param>
+        /// <param name="value">return value</param>
+        /// <returns>true if the value was in the dictionary, false otherwise</returns>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            if(_dictionary.TryGetValue(key, out (DateTime, TValue) v))
+            {
+                value = v.Item2;
+                return true;
+            }
+            value = default(TValue);
+            return false;
+        }
+
+        /// <summary>
+        /// Set value with the specified key
+        /// </summary>
+        /// <param name="key">Key to use</param>
+        /// <param name="value">value to insert</param>
+        public void SetValue(TKey key, TValue value)
+        {
+            _dictionary[key] = (DateTime.Now, value);
+        }
+
+        /// <summary>
+        /// Set value and inserted date with the specified key. should be used only when loading the dictionary from storage.
+        /// </summary>
+        /// <param name="key">Key to use</param>
+        /// <param name="value">value to insert</param>
+        /// <param name="date">date to insert</param>
+        public void SetValue(TKey key, TValue value, DateTime date)
+        {
+            _dictionary[key] = (date, value);
+        }
+
+        /// <summary>
+        /// Clears values older than 30 days from the dictionary.
+        /// </summary>
+        public void ClearOld()
+        {
+            var keys = _dictionary.Keys;
+            var oldestDate = DateTime.Now.AddDays(-30);
+            foreach(var key in keys)
+            {
+                if(_dictionary[key].Item1 < oldestDate)
+                _dictionary.Remove(key);
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of all values stored in the dictionary in an easier to serialize form.
+        /// </summary>
+        /// <returns>A list with the data</returns>
+        public List<(TKey, TValue, DateTime)> GetSerializedDictionary()
+        {
+            var srdc = new List<(TKey, TValue, DateTime)>();
+            var keys = _dictionary.Keys;
+            foreach(var key in keys)
+                srdc.Add((key, _dictionary[key].Item2, _dictionary[key].Item1));
+            return srdc;
+        }
+    }
+}

--- a/Editor/TimedDictionary.cs.meta
+++ b/Editor/TimedDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 155e5a123e83d7e45a4ad70da5d4da9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tools/EmbedLibraryWindow.cs
+++ b/Editor/Tools/EmbedLibraryWindow.cs
@@ -15,7 +15,7 @@ namespace VRLabs.SimpleShaderInspectors.Tools
     {
         private const string PATH = "Assets/VRLabs/SimpleShaderInspectors/Editor";
         private const string NAMESPACE = "VRLabs.SimpleShaderInspectors";
-        private const string IDENTIFIER = "SSI";
+        public const string IDENTIFIER = "SSI";
 
         private static readonly Regex _namespaceRegex = new Regex("^[a-zA-Z0-9.]*$");
 
@@ -137,7 +137,8 @@ namespace VRLabs.SimpleShaderInspectors.Tools
 
                     text = text.Replace(NAMESPACE, customNamespace + ".SimpleShaderInspectors");
 
-                    if (Path.GetFileName(file).Equals("Styles.cs"))
+                    string filePath = Path.GetFileName(file);
+                    if (filePath.Equals("Styles.cs") || filePath.Equals("StaticDictionaries.cs"))
                         text = text.Replace(IDENTIFIER, assetIdentifier);
                     
                     string finalPath = file.Replace(oldPath, newPath + "/SimpleShaderInspectors" + subpath);

--- a/Examples/Additive effects shader/Editor/SimpleSectionedShaderGUI.cs
+++ b/Examples/Additive effects shader/Editor/SimpleSectionedShaderGUI.cs
@@ -14,6 +14,11 @@ namespace VRLabs.SimpleShaderInspectorsExamples
         private Section _gChannel;
         private Section _bChannel;
         private Section _aChannel;
+        private OrderedSectionGroup _group;
+        private OrderedSection _ordered1;
+        private OrderedSection _ordered2;
+        private OrderedSection _ordered3;
+        private OrderedSection _ordered4;
         protected override void Start()
         {
             this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowUvOptions(true);
@@ -39,6 +44,24 @@ namespace VRLabs.SimpleShaderInspectorsExamples
             _aChannel.AddColorControl("_AColor").Alias("Alpha color");
             _aChannel.AddToggleControl("_AEmissive").Alias("Alpha emissive");
 
+            _layersSection.AddLabelControl("OrderedLabel");
+            _group = _layersSection.AddOrderedSectionGroup("Section group");
+            _ordered1 = _group.AddOrderedSection("_OrderedSection1").Alias("Ordered1");
+            _ordered1.AddColorControl("_RColor").Alias("Red color");
+            _ordered1.AddToggleControl("_REmissive").Alias("Red emissive");
+
+            _ordered2 = _group.AddOrderedSection("_OrderedSection2").Alias("Ordered2");
+            _ordered2.AddColorControl("_GColor").Alias("Green color");
+            _ordered2.AddToggleControl("_GEmissive").Alias("Green emissive");
+
+            _ordered3 = _group.AddOrderedSection("_OrderedSection3").Alias("Ordered3");
+            _ordered3.AddColorControl("_BColor").Alias("Blue color");
+            _ordered3.AddToggleControl("_BEmissive").Alias("Blue emissive");
+
+            _ordered4 = _group.AddOrderedSection("_OrderedSection4").Alias("Ordered4");
+            _ordered4.AddColorControl("_AColor").Alias("Alpha color");
+            _ordered4.AddToggleControl("_AEmissive").Alias("Alpha emissive");
+
             _rimSection = this.AddActivatableSection("_RimLightEnable").Alias("Rim light header")
                 .SetBackgroundColor(Color.yellow);
             _rimSection.AddColorControl("_RimLightColor").Alias("Rim color");
@@ -60,6 +83,7 @@ namespace VRLabs.SimpleShaderInspectorsExamples
             GUILayout.Label("- Space control");
             GUILayout.Label("- Sections");
             GUILayout.Label("- Activatable Sections");
+            GUILayout.Label("- Ordered Sections");
             GUILayout.Label("- Look customizations in sections");
             EditorGUI.indentLevel--;
             EditorGUILayout.Space();

--- a/Examples/Additive effects shader/Example.mat
+++ b/Examples/Additive effects shader/Example.mat
@@ -29,9 +29,13 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Floats:
     - _AEmissive: 0
-    - _AdditionalMasksEnable: 0
+    - _AdditionalMasksEnable: 1
     - _BEmissive: 0
     - _GEmissive: 0
+    - _OrderedSection1: 0
+    - _OrderedSection2: 0
+    - _OrderedSection3: 0
+    - _OrderedSection4: 0
     - _REmissive: 0
     - _RimLightEnable: 0
     - _RimLightPower: 0.284

--- a/Examples/Additive effects shader/Localization/Simple sectioned shader/English.json
+++ b/Examples/Additive effects shader/Localization/Simple sectioned shader/English.json
@@ -1,6 +1,36 @@
 {
     "Properties": [
         {
+            "Name": "OrderedLabel",
+            "DisplayName": "Ordered Sections:",
+            "Tooltip": ""
+        },
+        {
+            "Name": "Section group",
+            "DisplayName": "Add channel",
+            "Tooltip": "Add channel"
+        },
+        {
+            "Name": "Ordered1",
+            "DisplayName": "Red channel",
+            "Tooltip": "Red channel"
+        },
+        {
+            "Name": "Ordered2",
+            "DisplayName": "Green channel",
+            "Tooltip": "Green channel"
+        },
+        {
+            "Name": "Ordered3",
+            "DisplayName": "Blue channel",
+            "Tooltip": "Blue channel"
+        },
+        {
+            "Name": "Ordered4",
+            "DisplayName": "Alpha channel",
+            "Tooltip": "Alpha channel"
+        },
+        {
             "Name": "Rim power",
             "DisplayName": "Power",
             "Tooltip": "Power"

--- a/Examples/Additive effects shader/Simple sectioned shader.shader
+++ b/Examples/Additive effects shader/Simple sectioned shader.shader
@@ -5,7 +5,7 @@
         _Color ("Color", Color) = (1,1,1,1)
         _MainTex ("Albedo (RGB)", 2D) = "white" {}
         _AdditionalMasksEnable ("Additional Masks", float) = 0
-        _AdditionalMasks ("Masks)", 2D) = "black" {}
+        _AdditionalMasks ("Masks", 2D) = "black" {}
         _RColor ("Color", Color) = (1,1,1,1)
         _REmissive ("Emissive", float) = 0
         _GColor ("Color", Color) = (1,1,1,1)
@@ -17,6 +17,10 @@
         _RimLightEnable("Rim light", float) = 0
         _RimLightColor ("Color", Color) = (1,1,1,1)
         _RimLightPower("Power", Range(0,1)) = 0
+        _OrderedSection1 ("1", float) = 0
+        _OrderedSection2 ("2", float) = 0
+        _OrderedSection3 ("3", float) = 0
+        _OrderedSection4 ("4", float) = 0
     }
     SubShader
     {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <img src="https://img.shields.io/github/v/release/VRLabs/SimpleShaderInspectors.svg?style=flat-square">
   </a>
   <a href="https://github.com/VRLabs/SimpleShaderInspectors/releases/latest">
-    <img src="https://img.shields.io/badge/Unity-2018.4-green.svg?style=flat-square">
+    <img src="https://img.shields.io/badge/Unity-2019.4-green.svg?style=flat-square">
   </a>
   <br />
   <a href="https://github.com/VRLabs/SimpleShaderInspectors/issues">


### PR DESCRIPTION
Before the position of  OrderedSections relative to the others of the group was set in the material property directly. This could be an issue when the material property is used in some way in the shader that requires a specific number when enabled, regardless of the position of the section in editor.

With this update ordered sections will always use the library provided dictionary to store their position relative to the others. This values are stored in an asset  and have persistence for up to 30 days since last change in the material. Over that time it will simply lose its order in favour of the default one. The enabled state will not be lost since that's still stored in a MaterialProperty, with values that are decided by the constructor of the section (defaults: 0 for disabled, 1 for enabled).

The material property value will also take priority over the stored value in the dictionary, meaning that if in the dictionary there's a non 0 value stored to indicate that it is enabled in and in a specific position, but the property value is set to the disabled value, the section will be disabled and the dictionary value set to 0. On the other way around the section will be enabled and appended at the end of the sections.

This update also indirectly adds persistence to the data stored inside dictionaries, when before all values were lost on unity close.
The dictionary values are saved automatically on unity close (unless there is a editor crash, in that case it will lose changes, like everything else that is not saved in the project)