### PR TITLE
Fixed issue with Ordered Sections Reordering when using enable and disable values different from defaults

### DIFF
--- a/Editor/ChainableAttribute.cs
+++ b/Editor/ChainableAttribute.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors
 {
@@ -11,11 +8,9 @@ namespace VRLabs.SimpleShaderInspectors
     /// <remarks>
     /// The attribute by itself does nothing, but it is used by the chainables generator tool to generate extension methods for properties that have it
     /// </remarks>
-    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false)]
-    public class ChainableAttribute : System.Attribute
-    {
-        public ChainableAttribute() {}
-    }
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ChainableAttribute : Attribute
+    {}
 
     /// <summary>
     /// Attribute for constructors indicating that the chainable constructor can only be used from a specific type instead of the default IControlContainer type.
@@ -24,8 +19,8 @@ namespace VRLabs.SimpleShaderInspectors
     /// Sometimes you may need to limit which controls implementing IControlContainer can use the chainable version of the constructor, by having this attribute you can modify the generated 
     /// chainable constructor to reflect those needs.
     /// </remarks>
-    [System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false)]
-    public class LimitAccessScopeAttribute : System.Attribute
+    [AttributeUsage(AttributeTargets.Constructor)]
+    public class LimitAccessScopeAttribute : Attribute
     {
         public Type BaseType { get; }
         public LimitAccessScopeAttribute(Type type)

--- a/Editor/Controls/ControlContainer.cs
+++ b/Editor/Controls/ControlContainer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors.Controls
 {

--- a/Editor/Controls/GradientTextureControl.cs
+++ b/Editor/Controls/GradientTextureControl.cs
@@ -128,7 +128,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             AdditionalProperties[0] = new AdditionalProperty(colorPropertyName);
             if (!string.IsNullOrWhiteSpace(colorPropertyName))
             {
-                _hasExtra1 = true;
+                HasExtra1 = true;
             }
             GradientButtonStyle = Styles.Bubble;
             GradientEditorStyle = Styles.TextureBoxHeavyBorder;
@@ -161,7 +161,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (ShowUvOptions)
                 EditorGUILayout.BeginHorizontal();
             
-            if (_hasExtra1)
+            if (HasExtra1)
                 materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property);
             else
                 materialEditor.TexturePropertySingleLine(Content, Property);
@@ -169,10 +169,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (ShowUvOptions)
             {
                 GUI.backgroundColor = UVButtonColor;
-                _isUVButtonPressed = EditorGUILayout.Toggle(_isUVButtonPressed, UVButtonStyle, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
+                IsUVButtonPressed = EditorGUILayout.Toggle(IsUVButtonPressed, UVButtonStyle, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
                 EditorGUILayout.EndHorizontal();
-                if (_isUVButtonPressed)
+                if (IsUVButtonPressed)
                 {
                     GUI.backgroundColor = UVAreaColor;
                     EditorGUILayout.BeginVertical(UVAreaStyle);

--- a/Editor/Controls/KeywordToggleControl.cs
+++ b/Editor/Controls/KeywordToggleControl.cs
@@ -42,7 +42,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <value>
         /// String containing the keyword.
         /// </value>
-        protected readonly string keyword;
+        protected readonly string Keyword;
 
         private Material[] _materials;
 
@@ -53,7 +53,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <returns>A new <see cref="KeywordToggleControl"/> object.</returns>
         public KeywordToggleControl(string keyword) : base(keyword)
         {
-            this.keyword = keyword;
+            this.Keyword = keyword;
         }
 
         /// <summary>
@@ -65,16 +65,16 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (_materials == null)
                 _materials = Array.ConvertAll(materialEditor.targets, item => (Material)item);
             
-            EditorGUI.showMixedValue = _materials.IsKeywordMixedValue(keyword);
-            ToggleEnabled = _materials[0].IsKeywordEnabled(keyword);
+            EditorGUI.showMixedValue = _materials.IsKeywordMixedValue(Keyword);
+            ToggleEnabled = _materials[0].IsKeywordEnabled(Keyword);
 
             EditorGUI.BeginChangeCheck();
             ToggleEnabled = EditorGUILayout.Toggle(Content, ToggleEnabled);
             HasKeywordUpdated = EditorGUI.EndChangeCheck();
             if (HasKeywordUpdated)
             {
-                materialEditor.RegisterPropertyChangeUndo(keyword);
-                _materials.SetKeyword(keyword, ToggleEnabled);
+                materialEditor.RegisterPropertyChangeUndo(Keyword);
+                _materials.SetKeyword(Keyword, ToggleEnabled);
             }
 
             EditorGUI.showMixedValue = false;

--- a/Editor/Controls/KeywordToggleListControl.cs
+++ b/Editor/Controls/KeywordToggleListControl.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors.Controls
 {

--- a/Editor/Controls/LightmapEmissionControl.cs
+++ b/Editor/Controls/LightmapEmissionControl.cs
@@ -41,7 +41,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             HasLightmapEmissionUpdated = EditorGUI.EndChangeCheck();
             if (HasLightmapEmissionUpdated)
             {
-                foreach (Material mat in materialEditor.targets)
+                foreach (Material mat in Inspector.Materials)
                 {
                     MaterialEditor.FixupEmissiveFlag(mat);
                     bool shouldEmissionBeEnabled = (mat.globalIlluminationFlags & MaterialGlobalIlluminationFlags.EmissiveIsBlack) == 0;

--- a/Editor/Controls/Sections/ActivatableSection.cs
+++ b/Editor/Controls/Sections/ActivatableSection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -104,7 +103,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <param name="activatePropertyName">Material property that will drive the section enable state</param>
         /// <param name="enableValue">Float value that the material property will have if the section is disabled, optional (default: 0).</param>
         /// <param name="disableValue">Float value that the material property will have if the section is enabled, optional (default: 1).</param>
-        public ActivatableSection(string activatePropertyName, float enableValue = 1, float disableValue = 0) : base()
+        public ActivatableSection(string activatePropertyName, float enableValue = 1, float disableValue = 0)
         {
             AdditionalProperties = new AdditionalProperty[1];
             AdditionalProperties[0] = new AdditionalProperty(activatePropertyName);

--- a/Editor/Controls/Sections/OrderedSection.cs
+++ b/Editor/Controls/Sections/OrderedSection.cs
@@ -292,6 +292,17 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             AdditionalProperties[0].Property.floatValue = Enabled ? enableValue : disableValue;
             HasActivatePropertyUpdated = false;
         }
+        
+        public bool HasAtLeastOneMaterialDisabled()
+        {
+            bool yesItHas = false;
+            foreach (Material mat in Inspector.Materials)
+            {
+                yesItHas = Math.Abs(mat.GetFloat(AdditionalProperties[0].Property.name) - disableValue) < 0.001;
+                if (yesItHas) break;
+            }
+            return yesItHas;
+        }
 
         /// <summary>
         /// Draws the control represented by this object.

--- a/Editor/Controls/Sections/OrderedSection.cs
+++ b/Editor/Controls/Sections/OrderedSection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -51,8 +50,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// </summary>
         /// <value>0 when not moving, -1 when needs to go up, 1 when needs to go down.</value>
         public int PushState;
-        private bool isUp;
-        private bool isDown;
+        private bool _isUp;
+        private bool _isDown;
 
         /// <summary>
         /// Extra properties array. Implementation needed by <see cref="IAdditionalProperties"/>.
@@ -107,9 +106,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             set
             {
                 _sectionPosition = value;
-                if (string.IsNullOrWhiteSpace(positionDictionaryKey))
-                    positionDictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_SectionPosition";
-                StaticDictionaries.IntDictionary.SetValue(positionDictionaryKey, _sectionPosition);
+                if (string.IsNullOrWhiteSpace(_positionDictionaryKey))
+                    _positionDictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_SectionPosition";
+                StaticDictionaries.IntDictionary.SetValue(_positionDictionaryKey, _sectionPosition);
             }
         }
 
@@ -177,7 +176,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// </value>
         protected float disableValue;
 
-        private string positionDictionaryKey;
+        private string _positionDictionaryKey;
 
         /// <summary>
         /// Constructor of <see cref="OrderedSection"/> used when creating a property driven OrderedSection.
@@ -213,7 +212,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <param name="enableValue">Float value that the material property will have if the section is enabled, optional (default: 1).</param>
         /// <param name="disableValue">Float value that the material property will have if the section is disabled, optional (default: 0).</param>
         [LimitAccessScope(typeof(OrderedSectionGroup))]
-        public OrderedSection(string activatePropertyName, float enableValue = 1, float disableValue = 0) : base()
+        public OrderedSection(string activatePropertyName, float enableValue = 1, float disableValue = 0)
         {
             AdditionalProperties = new AdditionalProperty[1];
             AdditionalProperties[0] = new AdditionalProperty(activatePropertyName);
@@ -236,20 +235,20 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// </summary>
         protected void DrawSideButtons()
         {
-            Color bgcolor = GUI.backgroundColor;
+            Color bgColor = GUI.backgroundColor;
             GUI.backgroundColor = UpColor;
-            isUp = EditorGUILayout.Toggle(isUp, UpIcon, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
+            _isUp = EditorGUILayout.Toggle(_isUp, UpIcon, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
             GUI.backgroundColor = DownColor;
-            isDown = EditorGUILayout.Toggle(isDown, DownIcon, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
-            if (isUp)
+            _isDown = EditorGUILayout.Toggle(_isDown, DownIcon, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
+            if (_isUp)
             {
                 PushState = -1;
-                isUp = false;
+                _isUp = false;
             }
-            else if (isDown)
+            else if (_isDown)
             {
                 PushState = 1;
-                isDown = false;
+                _isDown = false;
             }
 
             EditorGUI.BeginChangeCheck();
@@ -261,25 +260,25 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
                 SectionPosition = 0;
             }
             HasActivatePropertyUpdated = EditorGUI.EndChangeCheck();
-            GUI.backgroundColor = bgcolor;
+            GUI.backgroundColor = bgColor;
         }
 
         public void PredrawUpdate(MaterialEditor materialEditor)
         {
             SetupEnabled(materialEditor);
 
-            if (string.IsNullOrWhiteSpace(positionDictionaryKey))
+            if (string.IsNullOrWhiteSpace(_positionDictionaryKey))
             {
-                positionDictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_SectionPosition";
+                _positionDictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_SectionPosition";
 
-                if (StaticDictionaries.IntDictionary.TryGetValue(positionDictionaryKey, out int position))
+                if (StaticDictionaries.IntDictionary.TryGetValue(_positionDictionaryKey, out int position))
                 {
                     _sectionPosition = position;
                 }
                 else
                 {
                     _sectionPosition = 0;
-                    StaticDictionaries.IntDictionary.SetValue(positionDictionaryKey, _sectionPosition);
+                    StaticDictionaries.IntDictionary.SetValue(_positionDictionaryKey, _sectionPosition);
                 }
                 
                 if(Math.Abs(AdditionalProperties[0].Property.floatValue - disableValue) > 0.001 && _sectionPosition == 0)

--- a/Editor/Controls/Sections/OrderedSectionGroup.cs
+++ b/Editor/Controls/Sections/OrderedSectionGroup.cs
@@ -169,7 +169,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         private static bool HasAtLeastOneDisabled(OrderedSection section)
         {
             bool yesItHas = false;
-            foreach (Material mat in section.AdditionalProperties[0].Property.targets)
+            foreach (Material mat in section.Inspector.Materials)
             {
                 yesItHas = mat.GetFloat(section.AdditionalProperties[0].Property.name) == 0;
                 if (yesItHas) break;

--- a/Editor/Controls/Sections/OrderedSectionGroup.cs
+++ b/Editor/Controls/Sections/OrderedSectionGroup.cs
@@ -120,7 +120,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             {
                 GenericMenu menu = new GenericMenu();
                 foreach (var section in Controls)
-                    if (HasAtLeastOneDisabled(section))
+                    if (section.HasAtLeastOneMaterialDisabled())
                         menu.AddItem(section.Content, false, TurnOnSection, section);
                 
                 menu.ShowAsContext();
@@ -160,21 +160,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             bool yesThereAre = false;
             foreach (var section in Controls)
             {
-                yesThereAre = HasAtLeastOneDisabled(section);
+                yesThereAre = section.HasAtLeastOneMaterialDisabled();
                 if (yesThereAre) break;
             }
             return yesThereAre;
-        }
-
-        private static bool HasAtLeastOneDisabled(OrderedSection section)
-        {
-            bool yesItHas = false;
-            foreach (Material mat in section.Inspector.Materials)
-            {
-                yesItHas = mat.GetFloat(section.AdditionalProperties[0].Property.name) == 0;
-                if (yesItHas) break;
-            }
-            return yesItHas;
         }
 
         /// <summary>

--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -167,7 +167,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <summary>
         /// Default constructor of <see cref="Section"/>.
         /// </summary>
-        public Section() : base("")
+        public Section() : base("SSI_UNUSED_PROP")
         {
             InitSection();
             UseDictionary = true;

--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -44,7 +44,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <value>
         /// Value of the material property when the section is open.
         /// </value>
-        protected readonly float showValue;
+        protected readonly float ShowValue;
 
         /// <summary>
         /// Float value that the Show bool gets converted if false.
@@ -52,7 +52,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <value>
         /// Value of the material property when the section is closed.
         /// </value>
-        protected readonly float hideValue;
+        protected readonly float HideValue;
 
         /// <summary>
         /// Boolean indicating if the section folding state is driven by an internal dictionary or not. It will be true in case you don't use a material property.
@@ -60,7 +60,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <value>
         /// True if it uses the internal dictionary, false when it uses a material property.
         /// </value>
-        protected readonly bool useDictionary;
+        protected readonly bool UseDictionary;
 
         /// <summary>
         /// String containing the key value that the section will use for the dictionary.
@@ -68,7 +68,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <value>
         /// The key used for the dictionary value.
         /// </value>
-        protected string dictionaryKey = null;
+        protected string DictionaryKey;
 
         /// <summary>
         /// Boolean indicating if it's the first ui update.
@@ -76,7 +76,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <value>
         /// True if it's the first UI update, false otherwise.
         /// </value>
-        protected bool firstCycle = true;
+        protected bool FirstCycle = true;
 
         /// <summary>
         /// List of controls inside this section.
@@ -159,9 +159,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         public Section(string propertyName, float hideValue = 0, float showValue = 1) : base(propertyName)
         {
             InitSection();
-            useDictionary = false;
-            this.hideValue = hideValue;
-            this.showValue = showValue;
+            UseDictionary = false;
+            this.HideValue = hideValue;
+            this.ShowValue = showValue;
         }
 
         /// <summary>
@@ -170,10 +170,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         public Section() : base("")
         {
             InitSection();
-            useDictionary = true;
+            UseDictionary = true;
             ControlAlias = "Section";
-            hideValue = 0;
-            showValue = 1;
+            HideValue = 0;
+            ShowValue = 1;
         }
 
         private void InitSection()
@@ -199,27 +199,27 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         protected void SetupEnabled(MaterialEditor materialEditor)
         {
             //bool previousShow = Show;
-            if (useDictionary)
+            if (UseDictionary)
             {
-                if (!firstCycle) return;
+                if (!FirstCycle) return;
                 
-                if (string.IsNullOrWhiteSpace(dictionaryKey))
-                    dictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_Show";
+                if (string.IsNullOrWhiteSpace(DictionaryKey))
+                    DictionaryKey = $"{ControlAlias}_{AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(Inspector.Materials[0]))}_Show";
                 
-                if (StaticDictionaries.BoolDictionary.TryGetValue(dictionaryKey, out bool show))
+                if (StaticDictionaries.BoolDictionary.TryGetValue(DictionaryKey, out bool show))
                 {
                     Show = show;
                 }
                 else
                 {
                     Show = false;
-                    StaticDictionaries.BoolDictionary.SetValue(dictionaryKey, Show);
+                    StaticDictionaries.BoolDictionary.SetValue(DictionaryKey, Show);
                 }
-                firstCycle = false;
+                FirstCycle = false;
             }
             else
             {
-                Show = Math.Abs(Property.floatValue - showValue) < 0.001;
+                Show = Math.Abs(Property.floatValue - ShowValue) < 0.001;
             }
         }
 
@@ -234,16 +234,16 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// </remarks>
         protected void UpdateEnabled(MaterialEditor materialEditor)
         {
-            if (useDictionary)
+            if (UseDictionary)
             {
-                StaticDictionaries.BoolDictionary.SetValue(dictionaryKey, Show);
+                StaticDictionaries.BoolDictionary.SetValue(DictionaryKey, Show);
             }
             else
             {
                 if (IsPropertyAnimatable)
                 {
                     materialEditor.RegisterPropertyChangeUndo(Property.displayName);
-                    Property.floatValue = Show ? showValue : hideValue;
+                    Property.floatValue = Show ? ShowValue : HideValue;
                 }
                 else
                 {
@@ -313,9 +313,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// <param name="materialEditor">Material editor.</param>
         public virtual void UpdateNonAnimatableProperty(MaterialEditor materialEditor)
         {
-            if (useDictionary || !HasPropertyUpdated) return;
+            if (UseDictionary || !HasPropertyUpdated) return;
             materialEditor.RegisterPropertyChangeUndo(Property.displayName);
-            Property.floatValue = Show ? showValue : hideValue;
+            Property.floatValue = Show ? ShowValue : HideValue;
         }
         
         public void AddControl(SimpleControl control) => Controls.Add(control);

--- a/Editor/Controls/SpaceControl.cs
+++ b/Editor/Controls/SpaceControl.cs
@@ -32,7 +32,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <summary>
         /// Default constructor of <see cref="LabelControl"/>.
         /// </summary>
-        /// <param name="alias">Alias of the control.</param>
+        /// <param name="space">amount of space to use, if set to 0 it defaults to 1 line worth of space.</param>
         /// <returns>A new <see cref="LabelControl"/> object.</returns>
         public SpaceControl(int space = 0) : base("")
         {

--- a/Editor/Controls/TextureControl.cs
+++ b/Editor/Controls/TextureControl.cs
@@ -34,7 +34,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <value>
         /// True if the control had the first extra property, false otherwise.
         /// </value>
-        protected bool _hasExtra1 = false;
+        protected bool HasExtra1;
 
         /// <summary>
         /// Indicates if the control has the second extra property.
@@ -42,7 +42,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <value>
         /// True if the control had the second extra property, false otherwise.
         /// </value>
-        protected bool _hasExtra2 = false;
+        protected bool HasExtra2;
 
         /// <summary>
         /// Indicates if the uv button is pressed and the tiling and offset area is visible.
@@ -50,7 +50,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <value>
         /// True if the button is pressed, false otherwise.
         /// </value>
-        protected bool _isUVButtonPressed = false;
+        protected bool IsUVButtonPressed;
 
         /// <summary>
         /// Extra properties array. Implementation of <see cref="IAdditionalProperties"/>.
@@ -126,11 +126,11 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             AdditionalProperties = new AdditionalProperty[2];
             AdditionalProperties[0] = new AdditionalProperty(extraPropertyName1);
             if (!string.IsNullOrWhiteSpace(extraPropertyName1))
-                _hasExtra1 = true;
+                HasExtra1 = true;
             
             AdditionalProperties[1] = new AdditionalProperty(extraPropertyName2);
             if (!string.IsNullOrWhiteSpace(extraPropertyName2))
-                _hasExtra2 = true;
+                HasExtra2 = true;
 
             UVButtonStyle = Styles.GearIcon;
             UVAreaStyle = Styles.TextureBoxHeavyBorder;
@@ -155,11 +155,11 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (ShowUvOptions)
                 EditorGUILayout.BeginHorizontal();
             
-            if (_hasExtra2)
+            if (HasExtra2)
             {
                 materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property, AdditionalProperties[1].Property);
             }
-            else if (_hasExtra1)
+            else if (HasExtra1)
             {
                 if (AdditionalProperties[0].Property.type == MaterialProperty.PropType.Color && HasHDRColor)
                     materialEditor.TexturePropertyWithHDRColorFixed(Content, Property, AdditionalProperties[0].Property, true);
@@ -173,10 +173,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (ShowUvOptions)
             {
                 GUI.backgroundColor = UVButtonColor;
-                _isUVButtonPressed = EditorGUILayout.Toggle(_isUVButtonPressed, UVButtonStyle, GUILayout.Width(16.0f), GUILayout.Height(16.0f));
+                IsUVButtonPressed = EditorGUILayout.Toggle(IsUVButtonPressed, UVButtonStyle, GUILayout.Width(16.0f), GUILayout.Height(16.0f));
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
                 EditorGUILayout.EndHorizontal();
-                if (_isUVButtonPressed)
+                if (IsUVButtonPressed)
                 {
                     GUI.backgroundColor = UVAreaColor;
                     EditorGUILayout.BeginVertical(UVAreaStyle);

--- a/Editor/Controls/TextureGeneratorControl.cs
+++ b/Editor/Controls/TextureGeneratorControl.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
-using VRLabs.SimpleShaderInspectors.Utility;
 
 namespace VRLabs.SimpleShaderInspectors.Controls
 {
@@ -11,7 +10,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
     /// <remarks>
     /// <para>
     /// It is a more complex and specialized version of <see cref="TextureControl"/>, where on top of the base functionality of <see cref="TextureControl"/> it also has
-    /// a fuull blown texture generator.
+    /// a full blown texture generator.
     /// </para>
     /// <para>
     /// When using it right away the texture generator will default to a simple 4 channel merger where for each channel you can select a texture, select which channel of
@@ -39,14 +38,14 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         private readonly AdditionalLocalization[] _textureContent;
         private readonly AdditionalLocalization[] _colorContent;
         private readonly AdditionalLocalization[] _namesContent;
-        private bool _isGeneratorOpen = false;
+        private bool _isGeneratorOpen;
         private readonly ComputeShader _compute;
         private readonly string _kernelName;
         private Resolution _resolution;
         private readonly List<ComputeInputBase> _inputs;
         private RenderTexture _result;
         private Texture2D _resultTex;
-        private readonly bool _containsTextures = false;
+        private readonly bool _containsTextures;
 
         private static readonly string[] _baseNames =
                         {
@@ -65,7 +64,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             "ColorSpace"            //[0]
         };
 
-        private readonly bool _containsColors = false;
+        private readonly bool _containsColors;
 
         /// <summary>
         /// Style for the texture generator button.
@@ -169,6 +168,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <summary>
         /// Default constructor of <see cref="TextureGeneratorControl"/>
         /// </summary>
+        /// <param name="compute">Compute shader used</param>
+        /// <param name="computeOptionsJson">Settings Json used for the compute shader</param>
         /// <param name="propertyName">Material property name.</param>
         /// <param name="extraPropertyName1">First additional material property name. Optional.</param>
         /// <param name="extraPropertyName2">Second additional material property name. Optional.</param>
@@ -277,11 +278,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
                     }
                 }
 
-                AdditionalLocalization[] selectedArray;
-                if (_inputs[i] is ComputeTextureInput)
-                    selectedArray = _textureContent;
-                else
-                    selectedArray = _colorContent;
+                AdditionalLocalization[] selectedArray = _inputs[i] is ComputeTextureInput ? _textureContent : _colorContent;
                 
                 GUI.backgroundColor = GeneratorInputColor;
                 EditorGUILayout.BeginVertical(GeneratorInputStyle);

--- a/Editor/Controls/TextureGeneratorHelper.cs
+++ b/Editor/Controls/TextureGeneratorHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -141,19 +140,19 @@ namespace VRLabs.SimpleShaderInspectors.Controls
                         break;
                 }
             }
-            ComputeInputs.TextureMetadata textureMetadata = new ComputeInputs.TextureMetadata
+            var textureMetadata = new ComputeInputs.TextureMetadata
             {
-                Width = def?.width ?? Texture.width,
-                Height = def?.height ?? Texture.height,
+                Width = def != null ? def.width : Texture.width,
+                Height = def != null ? def.height : Texture.height,
                 SelectedChannel = Channel,
                 Reverse = Invert ? 1 : 0,
                 Gamma = IsGamma()
             };
 
-            ComputeInputs.TextureData textureData = new ComputeInputs.TextureData
+            var textureData = new ComputeInputs.TextureData
             {
                 Name = InputName,
-                Texture = def ?? Texture
+                Texture = def != null ? def : Texture
             };
 
             inputs.Textures.Add(textureData);
@@ -167,7 +166,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             rect.x += 10; rect.y += 5;
             rect.width -= 20; rect.height -= 10;
             Texture = (Texture2D)EditorGUI.ObjectField(rect, Texture, typeof(Texture2D), false);
-            if (UseSpecificChannel) Channel = GUILayout.Toolbar(Channel, new string[] { "R", "G", "B", "A" }); //extraContent[0].Content,
+            if (UseSpecificChannel) Channel = GUILayout.Toolbar(Channel, new[] { "R", "G", "B", "A" }); //extraContent[0].Content,
             if (UseInvert)
             {
                 rect = GUILayoutUtility.GetRect(100, 16);
@@ -219,7 +218,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         {
             GUILayout.Label(name);
             EditorGUILayout.ColorField(Color);
-            if (UseColorspace) Colorspace = GUILayout.Toolbar(Colorspace, new string[] { "Linear", "Gamma" }, EditorStyles.miniLabel); //extraContent[1].Content
+            if (UseColorspace) Colorspace = GUILayout.Toolbar(Colorspace, new [] { "Linear", "Gamma" }, EditorStyles.miniLabel); //extraContent[1].Content
         }
     }
 

--- a/Editor/Controls/TilingAndOffsetControl.cs
+++ b/Editor/Controls/TilingAndOffsetControl.cs
@@ -1,7 +1,5 @@
 using UnityEditor;
 
-using VRLabs.SimpleShaderInspectors;
-
 namespace VRLabs.SimpleShaderInspectors.Controls
 {
     /// <summary>

--- a/Editor/Controls/ToggleControl.cs
+++ b/Editor/Controls/ToggleControl.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors.Controls
 {
@@ -29,15 +28,15 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <value>
         /// Float value of the property if the toggle is disabled.
         /// </value>
-        protected readonly float falseValue;
+        protected readonly float FalseValue;
 
         /// <summary>
         /// Float value that the Enabled bool gets converted if true.
         /// </summary>
         /// <value>
-        /// Float value of the proeprty if the toggle is enabled
+        /// Float value of the property if the toggle is enabled
         /// </value>
-        protected readonly float trueValue;
+        protected readonly float TrueValue;
 
         /// <summary>
         /// Boolean indicating if the toggle is enabled or not.
@@ -45,7 +44,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <value>
         /// True if the toggle is enabled, false otherwise.
         /// </value>
-        public bool ToggleEnabled => Math.Abs((Property?.floatValue ?? 0) - trueValue) < 0.001;
+        public bool ToggleEnabled => Math.Abs((Property?.floatValue ?? 0) - TrueValue) < 0.001;
 
         /// <summary>
         /// Default constructor of <see cref="ToggleControl"/>
@@ -56,8 +55,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         /// <returns>A new <see cref="ToggleControl"/> object.</returns>
         public ToggleControl(string propertyName, float falseValue = 0, float trueValue = 1) : base(propertyName)
         {
-            this.falseValue = falseValue;
-            this.trueValue = trueValue;
+            this.FalseValue = falseValue;
+            this.TrueValue = trueValue;
         }
 
         /// <summary>
@@ -74,7 +73,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (HasPropertyUpdated)
             {
                 materialEditor.RegisterPropertyChangeUndo(Property.displayName);
-                Property.floatValue = toggle ? trueValue : falseValue;
+                Property.floatValue = toggle ? TrueValue : FalseValue;
             }
 
             EditorGUI.showMixedValue = false;

--- a/Editor/Controls/ToggleListControl.cs
+++ b/Editor/Controls/ToggleListControl.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors.Controls
 {

--- a/Editor/Controls/VectorControl.cs
+++ b/Editor/Controls/VectorControl.cs
@@ -102,11 +102,13 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             int oldIndentLevel = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
             // I'll be honest, it looks somewhat retarded, but it's not worth to make an array and cycle it, it would waste more resources.
-            Vector4 vector = new Vector4(0, 0, 0, 0);
-            vector.x = IsXVisible ? DrawSingleField("X", Property.vectorValue.x, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.x;
-            vector.y = IsYVisible ? DrawSingleField("Y", Property.vectorValue.y, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.y;
-            vector.z = IsZVisible ? DrawSingleField("Z", Property.vectorValue.z, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.z;
-            vector.w = IsWVisible ? DrawSingleField("W", Property.vectorValue.w, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.w;
+            Vector4 vector = new Vector4(0, 0, 0, 0)
+            {
+                x = IsXVisible ? DrawSingleField("X", Property.vectorValue.x, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.x,
+                y = IsYVisible ? DrawSingleField("Y", Property.vectorValue.y, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.y,
+                z = IsZVisible ? DrawSingleField("Z", Property.vectorValue.z, GetFragmentedRect(r, _visibleCount, i++)) : Property.vectorValue.z,
+                w = IsWVisible ? DrawSingleField("W", Property.vectorValue.w, GetFragmentedRect(r, _visibleCount, i)) : Property.vectorValue.w
+            };
 
             HasPropertyUpdated = EditorGUI.EndChangeCheck();
             if (HasPropertyUpdated)

--- a/Editor/Controls/VertexStreamsControl.cs
+++ b/Editor/Controls/VertexStreamsControl.cs
@@ -106,6 +106,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         private void CacheRenderers(Material material)
         {
             ParticleSystemRenderer[] renderers = Resources.FindObjectsOfTypeAll(typeof(ParticleSystemRenderer)) as ParticleSystemRenderer[];
+            if (renderers == null) return;
             foreach (var renderer in renderers)
             {
                 var go = renderer.gameObject;

--- a/Editor/IAdditionalLocalization.cs
+++ b/Editor/IAdditionalLocalization.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors

--- a/Editor/IAdditionalProperties.cs
+++ b/Editor/IAdditionalProperties.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors
 {
@@ -62,10 +60,7 @@ namespace VRLabs.SimpleShaderInspectors
             if (_propertyIndex == -2)
                 SetPropertyIndex(properties);
 
-            if (_propertyIndex != -1)
-                Property = properties[_propertyIndex];
-            else
-                Property = null;
+            Property = _propertyIndex != -1 ? properties[_propertyIndex] : null;
         }
     }
 }

--- a/Editor/IControlContainer.cs
+++ b/Editor/IControlContainer.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using UnityEditor;
-using VRLabs.SimpleShaderInspectors.Controls;
 
 namespace VRLabs.SimpleShaderInspectors
 {

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors

--- a/Editor/PropertyControl.cs
+++ b/Editor/PropertyControl.cs
@@ -1,5 +1,4 @@
 using UnityEditor;
-using UnityEngine;
 
 namespace VRLabs.SimpleShaderInspectors
 {
@@ -75,10 +74,7 @@ namespace VRLabs.SimpleShaderInspectors
             if (_propertyIndex == -2)
                 SetPropertyIndex(properties);
 
-            if (_propertyIndex != -1)
-                Property = properties[_propertyIndex];
-            else
-                Property = null;
+            Property = _propertyIndex != -1 ? properties[_propertyIndex] : null;
         }
     }
 }

--- a/Editor/SSIHelper.cs
+++ b/Editor/SSIHelper.cs
@@ -46,7 +46,7 @@ namespace VRLabs.SimpleShaderInspectors
                 if (control is PropertyControl pr)
                 {
                     pr.FetchProperty(properties);
-                    if(pr.Property == null)
+                    if(pr.Property == null && !pr.PropertyName.Equals("SSI_UNUSED_PROP"))
                         errs.Add(pr.PropertyName);
                 }
 
@@ -94,6 +94,8 @@ namespace VRLabs.SimpleShaderInspectors
         /// <returns>The material property with the wanted name.</returns>
         internal static int FindPropertyIndex(string propertyName, MaterialProperty[] properties, bool propertyIsMandatory = false)
         {
+            if (!string.IsNullOrWhiteSpace(propertyName) && propertyName.Equals("SSI_UNUSED_PROP")) return -1;
+            
             for (int i = 0; i < properties.Length; i++)
                 if (properties[i] != null && properties[i].name == propertyName)
                     return i;

--- a/Editor/SSIHelper.cs
+++ b/Editor/SSIHelper.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace VRLabs.SimpleShaderInspectors
 {
@@ -34,6 +33,43 @@ namespace VRLabs.SimpleShaderInspectors
         }
 
         /// <summary>
+        /// Fetches properties for all the given controls.
+        /// </summary>
+        /// <param name="controls">Controls needing to fetch properties.</param>
+        /// <param name="properties">Property array to fetch properties from.</param>
+        /// <param name="missingProperties">(Out) Properties defined in the inspector that are missing in the shader</param>
+        public static void FetchProperties(this IEnumerable<SimpleControl> controls, MaterialProperty[] properties, out List<string> missingProperties)
+        {
+            var errs = new List<string>();
+            foreach (var control in controls)
+            {
+                if (control is PropertyControl pr)
+                {
+                    pr.FetchProperty(properties);
+                    if(pr.Property == null)
+                        errs.Add(pr.PropertyName);
+                }
+
+                if (control is IAdditionalProperties add)
+                {
+                    foreach (var t in add.AdditionalProperties)
+                    {
+                        t.FetchProperty(properties);
+                        if(t.Property == null)
+                            errs.Add(t.PropertyName);
+                    }
+                }
+
+                if (control is IControlContainer con)
+                {
+                    con.GetControlList().FetchProperties(properties, out List<string> ms);
+                    errs.AddRange(ms);
+                }
+            }
+            missingProperties = errs;
+        }
+
+        /// <summary>
         /// Set the inspector of each control of the list.
         /// </summary>
         /// <param name="controls">Controls this method extends from.</param>
@@ -52,7 +88,7 @@ namespace VRLabs.SimpleShaderInspectors
         /// <summary>
         /// Find a material property from its name.
         /// </summary>
-        /// <param name="propertyName">Name of the material proeperty.</param>
+        /// <param name="propertyName">Name of the material property.</param>
         /// <param name="properties">Array of material properties to search from.</param>
         /// <param name="propertyIsMandatory">Boolean indicating if it's mandatory to find the requested material property</param>
         /// <returns>The material property with the wanted name.</returns>
@@ -73,7 +109,7 @@ namespace VRLabs.SimpleShaderInspectors
         /// Finds all controls that implement the INonAnimatableProperty interface.
         /// </summary>
         /// <param name="controls">Controls to search from</param>
-        /// <returns>An enumerable containing all INonAnimarableProperty instances found</returns>
+        /// <returns>An enumerable containing all INonAnimatableProperty instances found</returns>
         public static IEnumerable<INonAnimatableProperty> FindNonAnimatablePropertyControls(this IEnumerable<SimpleControl> controls)
         {
             List<INonAnimatableProperty> nonAnimatablePropertyControls = new List<INonAnimatableProperty>();
@@ -117,7 +153,7 @@ namespace VRLabs.SimpleShaderInspectors
 
                 foreach (var t in windowInstances)
                 {
-                    bool isRecording = (bool)isRecordingProp.GetValue
+                    bool isRecording = isRecordingProp != null && (bool)isRecordingProp.GetValue
                         (t, null);
 
                     if (!isRecording) continue;
@@ -142,8 +178,7 @@ namespace VRLabs.SimpleShaderInspectors
             }
             else
             {
-                foreach (var t in propertiesNeedingUpdate)
-                    SetNonAnimatableProperties(materialEditor, propertiesNeedingUpdate);
+                SetNonAnimatableProperties(materialEditor, propertiesNeedingUpdate);
             }
         }
         
@@ -166,8 +201,8 @@ namespace VRLabs.SimpleShaderInspectors
         public static string GetTextureDestinationPath(Material mat, string name)
         {
             string path = AssetDatabase.GetAssetPath(mat);
-            path = Directory.GetParent(path).FullName;
-            string pathParent = Directory.GetParent(path).FullName;
+            path = Directory.GetParent(path)?.FullName;
+            string pathParent = Directory.GetParent(path)?.FullName;
 
             if (Directory.Exists(pathParent + "/Textures/"))
                 return pathParent + "/Textures/" + mat.name + name;
@@ -185,12 +220,16 @@ namespace VRLabs.SimpleShaderInspectors
         {
             byte[] bytes = texture.EncodeToPNG();
 
-            System.IO.File.WriteAllBytes(path, bytes);
+            File.WriteAllBytes(path, bytes);
             AssetDatabase.Refresh();
-            path = path.Substring(path.LastIndexOf("Assets"));
+            path = path.Substring(path.LastIndexOf("Assets", StringComparison.Ordinal));
             var t = AssetImporter.GetAtPath(path) as TextureImporter;
-            t.wrapMode = mode;
-            t.isReadable = true;
+            if (t != null)
+            {
+                t.wrapMode = mode;
+                t.isReadable = true;
+            }
+
             AssetDatabase.ImportAsset(path);
         }
 
@@ -204,7 +243,7 @@ namespace VRLabs.SimpleShaderInspectors
         public static Texture2D SaveAndGetTexture(Texture2D texture, string path, TextureWrapMode mode = TextureWrapMode.Repeat)
         {
             SaveTexture(texture, path, mode);
-            path = path.Substring(path.LastIndexOf("Assets"));
+            path = path.Substring(path.LastIndexOf("Assets", StringComparison.Ordinal));
             return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
         }
 

--- a/Editor/SerializedDictionaries.cs
+++ b/Editor/SerializedDictionaries.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEditor;
 using System;
 using System.Collections.Generic;
 

--- a/Editor/SimpleControl.cs
+++ b/Editor/SimpleControl.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEditor;
 using UnityEngine;
 

--- a/Editor/SimpleShaderInspector.cs
+++ b/Editor/SimpleShaderInspector.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using System;
-using Object = UnityEngine.Object;
 
 
 namespace VRLabs.SimpleShaderInspectors
@@ -172,7 +171,7 @@ namespace VRLabs.SimpleShaderInspectors
                 SSIHelper.UpdateNonAnimatableProperties(_nonAnimatablePropertyControls, materialEditor, NeedsNonAnimatableUpdate);
 
             // Draw footer and inspector logo.
-            DrawFooter(materialEditor);
+            DrawFooter();
 
             CheckChanges(materialEditor);
         }
@@ -261,7 +260,7 @@ namespace VRLabs.SimpleShaderInspectors
         }
         
         // Draws the footer
-        private void DrawFooter(MaterialEditor materialEditor)
+        private void DrawFooter()
         {
             GUILayout.FlexibleSpace();
             EditorGUILayout.BeginHorizontal();

--- a/Editor/StaticDictionaries.cs
+++ b/Editor/StaticDictionaries.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 
@@ -57,7 +56,7 @@ namespace VRLabs.SimpleShaderInspectors
             foreach(SerializedDictionaries.BoolItem item in _dictionaries.boolDictionary)
                 _boolDictionary.SetValue(item.key, item.value, DateTime.FromBinary(item.date));
 
-             _intDictionary = new TimedDictionary<string, int>();
+            _intDictionary = new TimedDictionary<string, int>();
             foreach(SerializedDictionaries.IntItem item in _dictionaries.intDictionary)
                 _intDictionary.SetValue(item.key, item.value, DateTime.FromBinary(item.date));
         }
@@ -69,14 +68,12 @@ namespace VRLabs.SimpleShaderInspectors
 
             private static void SaveAsset()
             {
-                if(_dictionaries != null) 
-                {
-                    StaticDictionaries.BoolDictionary.ClearOld();
-                    StaticDictionaries.IntDictionary.ClearOld();
-                    _dictionaries.SetBoolDictionary(StaticDictionaries.BoolDictionary.GetSerializedDictionary());
-                    _dictionaries.SetIntDictionary(StaticDictionaries.IntDictionary.GetSerializedDictionary());
-                    EditorUtility.SetDirty(_dictionaries);
-                }
+                if (_dictionaries == null) return;
+                BoolDictionary.ClearOld();
+                IntDictionary.ClearOld();
+                _dictionaries.SetBoolDictionary(BoolDictionary.GetSerializedDictionary());
+                _dictionaries.SetIntDictionary(IntDictionary.GetSerializedDictionary());
+                EditorUtility.SetDirty(_dictionaries);
             }
         }
     }

--- a/Editor/Styles.cs
+++ b/Editor/Styles.cs
@@ -56,7 +56,7 @@ namespace VRLabs.SimpleShaderInspectors
     /// </summary>
     public static class ComputeShaders
     {
-        private static ComputeShader _RGBAPacker;
+        private static ComputeShader _rgbaPacker;
         /// <summary>
         /// Compute shader that packs 4 texture channels into a single texture.
         /// </summary>
@@ -64,9 +64,9 @@ namespace VRLabs.SimpleShaderInspectors
         {
             get
             {
-                if (_RGBAPacker != null) return _RGBAPacker;
-                _RGBAPacker = Resources.Load<ComputeShader>("ComputeShaders/SSIRGBAPacker");
-                return _RGBAPacker;
+                if (_rgbaPacker != null) return _rgbaPacker;
+                _rgbaPacker = Resources.Load<ComputeShader>("ComputeShaders/SSIRGBAPacker");
+                return _rgbaPacker;
             }
         }
         /// <summary>
@@ -191,7 +191,7 @@ namespace VRLabs.SimpleShaderInspectors
             }
         }
 
-        private static Texture2D _SSILogoLight;
+        private static Texture2D _ssiLogoLight;
         /// <summary>
         /// Simple Shader Inspectors logo for light theme.
         /// </summary>
@@ -199,15 +199,15 @@ namespace VRLabs.SimpleShaderInspectors
         {
             get
             {
-                if (_SSILogoLight != null) return _SSILogoLight;
+                if (_ssiLogoLight != null) return _ssiLogoLight;
 
-                _SSILogoLight = Resources.Load<Texture2D>("Textures/Logo/SSILogoLight");
-                return _SSILogoLight;
+                _ssiLogoLight = Resources.Load<Texture2D>("Textures/Logo/SSILogoLight");
+                return _ssiLogoLight;
 
             }
         }
 
-        private static Texture2D _SSILogoDark;
+        private static Texture2D _ssiLogoDark;
         /// <summary>
         /// Simple Shader Inspectors logo for dark theme.
         /// </summary>
@@ -215,10 +215,10 @@ namespace VRLabs.SimpleShaderInspectors
         {
             get
             {
-                if (_SSILogoDark != null) return _SSILogoDark;
+                if (_ssiLogoDark != null) return _ssiLogoDark;
 
-                _SSILogoDark = Resources.Load<Texture2D>("Textures/Logo/SSILogoDark");
-                return _SSILogoDark;
+                _ssiLogoDark = Resources.Load<Texture2D>("Textures/Logo/SSILogoDark");
+                return _ssiLogoDark;
             }
         }
 

--- a/Editor/TimedDictionary.cs
+++ b/Editor/TimedDictionary.cs
@@ -73,7 +73,7 @@ namespace VRLabs.SimpleShaderInspectors
             foreach(var key in keys)
             {
                 if(_dictionary[key].Item1 < oldestDate)
-                _dictionary.Remove(key);
+                    _dictionary.Remove(key);
             }
         }
 
@@ -83,11 +83,11 @@ namespace VRLabs.SimpleShaderInspectors
         /// <returns>A list with the data</returns>
         public List<(TKey, TValue, DateTime)> GetSerializedDictionary()
         {
-            var srdc = new List<(TKey, TValue, DateTime)>();
+            var serializedDictionary = new List<(TKey, TValue, DateTime)>();
             var keys = _dictionary.Keys;
             foreach(var key in keys)
-                srdc.Add((key, _dictionary[key].Item2, _dictionary[key].Item1));
-            return srdc;
+                serializedDictionary.Add((key, _dictionary[key].Item2, _dictionary[key].Item1));
+            return serializedDictionary;
         }
     }
 }

--- a/Editor/Tools/ChainableGeneratorWindow.cs
+++ b/Editor/Tools/ChainableGeneratorWindow.cs
@@ -24,8 +24,8 @@ namespace VRLabs.SimpleShaderInspectors.Tools
             return window;
         }
 
-        private string _destinationPath = null;
-        private string _namespace = null;
+        private string _destinationPath;
+        private string _namespace;
 
         void OnGUI()
         {
@@ -95,7 +95,7 @@ namespace VRLabs.SimpleShaderInspectors.Tools
                 content.Append(Indentation(indent))
                     .AppendLine("}");
 
-                File.WriteAllText($"{destinationPath}\\{group.Key}.Chainables.cs", content.ToString().Replace("\r\n", "\n"), System.Text.Encoding.UTF8);
+                File.WriteAllText($"{destinationPath}\\{group.Key}.Chainables.cs", content.ToString().Replace("\r\n", "\n"), Encoding.UTF8);
             }
 
             AssetDatabase.Refresh();
@@ -121,19 +121,14 @@ namespace VRLabs.SimpleShaderInspectors.Tools
         }
 
         // Append a chainable constructor implementation to the given content.
-        private static void BuildConstructorChainable(StringBuilder content, Type type, System.Reflection.ConstructorInfo constructor, int indentLevel)
+        private static void BuildConstructorChainable(StringBuilder content, Type type, ConstructorInfo constructor, int indentLevel)
         {
             // Check if the constructor has the limitAccessScope attribute to limit the objects that can access the chainable
             LimitAccessScopeAttribute limitScopeAttribute =
                 (LimitAccessScopeAttribute)Array.Find(constructor.GetCustomAttributes(false), x => x.GetType() == typeof(LimitAccessScopeAttribute));
 
-            string typeName;
-            if (limitScopeAttribute != null)
-                typeName = limitScopeAttribute.BaseType.Name;
-            else
-                typeName = "VRLabs.SimpleShaderInspectors.IControlContainer";
-
-
+            string typeName = limitScopeAttribute != null ? limitScopeAttribute.BaseType.Name : "VRLabs.SimpleShaderInspectors.IControlContainer";
+            
             // Chainable constructor header
             content.Append(Indentation(indentLevel))
                 .Append($"public static {GenerateGenericListString(type)} Add{GenerateGenericListString(type)}(this {typeName} container");
@@ -159,13 +154,13 @@ namespace VRLabs.SimpleShaderInspectors.Tools
             indentLevel++;
             content.Append(Indentation(indentLevel))
                 .Append("var control = new ").Append(GenerateGenericListString(type)).Append('(');
-            bool needcomma = false;
+            bool needComma = false;
             foreach (var parameter in constructor.GetParameters())
             {
-                if (needcomma)
+                if (needComma)
                     content.Append(", ");
                 else
-                    needcomma = true;
+                    needComma = true;
                 content.Append(parameter.Name);
             }
             content.AppendLine(");")

--- a/Editor/Tools/LocalizationEditorWindow.cs
+++ b/Editor/Tools/LocalizationEditorWindow.cs
@@ -1,10 +1,7 @@
 using UnityEditor;
 using UnityEngine;
-using System;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using UnityEditorInternal;
 
 namespace VRLabs.SimpleShaderInspectors.Tools
@@ -23,17 +20,23 @@ namespace VRLabs.SimpleShaderInspectors.Tools
         }
 
         private PropertyInfo _activeProperty;
-        private bool _enableNameEditing = false;
+        private bool _enableNameEditing;
         private ReorderableList _list;
         private List<PropertyInfo> _properties;
         private GUIStyle _rightSubLabel;
-        private string _selectedPath = null;
+        private string _selectedPath;
         private Vector2 _scroll;
 
         private void OnEnable()
         {
-            _rightSubLabel = new GUIStyle { alignment = TextAnchor.MiddleRight };
-            _rightSubLabel.normal.textColor = Color.gray;
+            _rightSubLabel = new GUIStyle
+            {
+                alignment = TextAnchor.MiddleRight,
+                normal =
+                {
+                    textColor = Color.gray
+                }
+            };
         }
 
         void OnGUI()
@@ -114,13 +117,13 @@ namespace VRLabs.SimpleShaderInspectors.Tools
                 _list = new ReorderableList(_properties, typeof(PropertyInfo), true, false, true, true)
                 {
                     drawElementCallback = DrawListItems,
-                    onSelectCallback = (ReorderableList l) =>
+                    onSelectCallback = l =>
                     {
                         _activeProperty = _properties[l.index];
                         _enableNameEditing = false;
-                    }
+                    },
+                    index = 0
                 };
-                _list.index = 0;
                 _activeProperty = _properties[0];
             }
             else

--- a/Editor/Utility/GradientTexture.cs
+++ b/Editor/Utility/GradientTexture.cs
@@ -1,5 +1,5 @@
+using System;
 using UnityEngine;
-using UnityEditor;
 using System.Collections.Generic;
 namespace VRLabs.SimpleShaderInspectors.Utility
 {
@@ -20,7 +20,6 @@ namespace VRLabs.SimpleShaderInspectors.Utility
         /// <summary>
         /// List of gradient keys.
         /// </summary>
-        [SerializeField]
         public List<ColorKey> Keys = new List<ColorKey>();
 
         /// <summary>
@@ -100,7 +99,7 @@ namespace VRLabs.SimpleShaderInspectors.Utility
                     return i;
                 }
 
-                if (time == Keys[i].Time && shouldDelete)
+                if (Math.Abs(time - Keys[i].Time) < 0.001 && shouldDelete)
                 {
                     Keys[i] = new ColorKey(color, time);
                     UpdateTexture();
@@ -211,7 +210,7 @@ namespace VRLabs.SimpleShaderInspectors.Utility
         /// <summary>
         /// Structure containing a color and a float indicating at which time the color is.
         /// </summary>
-        [System.Serializable]
+        [Serializable]
         public struct ColorKey
         {
             /// <summary>


### PR DESCRIPTION
Ordered sections groups would still show the add button in case the an ordered section would not use the default values (specifically for the disable value).

Also on the side there are a couple of new helper functions in general, but no one cares about those