### PR TITLE
Updated ordered section groups to have searchable sections

### DIFF
--- a/Editor/Controls/Sections/OrderedSection.cs
+++ b/Editor/Controls/Sections/OrderedSection.cs
@@ -43,7 +43,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
     /// group.AddOrderedSection("_ActivateProperty", "_ShowProperty", 2, 3, 4, 6); 
     /// </code>
     /// </example>
-    public class OrderedSection : Section, IAdditionalProperties
+    public class OrderedSection : Section, IAdditionalProperties, IAdditionalLocalization
     {
         /// <summary>
         /// Indicates if the section should be pushed up or down relative to its neighbour sections.
@@ -69,6 +69,17 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         /// </list>
         /// </remarks>
         public AdditionalProperty[] AdditionalProperties { get; set; }
+        
+        /// <summary>
+        /// Extra localization array. Implementation needed by <see cref="IAdditionalLocalization"/>.
+        /// </summary>
+        /// <value>
+        /// Array of <see cref="AdditionalLocalization"/>
+        /// </value>
+        /// <remarks>
+        /// This array will contain 1 element containing the custom path for the ordered section item in the popup menu of the <see cref="OrderedSectionGroup"/> add button.
+        /// </remarks>
+        public AdditionalLocalization[] AdditionalContent { get; set; }
 
         /// <summary>
         /// Boolean indicating if the activate property has been updated this cycle.
@@ -111,6 +122,16 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
                 StaticDictionaries.IntDictionary.SetValue(_positionDictionaryKey, _sectionPosition);
             }
         }
+
+        /// <summary>
+        /// Custom path for the selection inside the popup of the ordered section group
+        /// </summary>
+        /// <value>The custom path (does not include the section name itself</value>
+        /// <remarks>
+        /// The custom path is taken directly from the localization of it, so that different languages can have their own path names.
+        /// If the path found in the localization equals to the combined "Alias_Name" used for finding the localization, it will automatically be assumed that no path has been given
+        /// </remarks>
+        public string CustomPopupPath => AdditionalContent[0].Content.text.Equals(ControlAlias + "_" + AdditionalContent[0].Name) ? "" : AdditionalContent[0].Content.text;
 
         /// <summary>
         /// Style for the up icon.
@@ -194,6 +215,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             AdditionalProperties = new AdditionalProperty[1];
             AdditionalProperties[0] = new AdditionalProperty(activatePropertyName);
 
+            AdditionalContent = new AdditionalLocalization[1];
+            AdditionalContent[0] = new AdditionalLocalization{Name = "Path"};
+
             UpIcon = Styles.UpIcon;
             DownIcon = Styles.DownIcon;
             DeleteIcon = Styles.DeleteIcon;
@@ -216,6 +240,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
         {
             AdditionalProperties = new AdditionalProperty[1];
             AdditionalProperties[0] = new AdditionalProperty(activatePropertyName);
+            
+            AdditionalContent = new AdditionalLocalization[1];
+            AdditionalContent[0] = new AdditionalLocalization{Name = "Path"};
 
             ControlAlias = activatePropertyName;
 

--- a/Editor/Controls/Sections/OrderedSectionDropdown.cs
+++ b/Editor/Controls/Sections/OrderedSectionDropdown.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+
+namespace VRLabs.SimpleShaderInspectors.Controls.Sections
+{
+    /// <summary>
+    /// Dropdown used by the <see cref="OrderedSectionGroup"/> and used to give the user a searchable dropdown to enable disabled sections.
+    /// </summary>
+    public class OrderedSectionDropdown : AdvancedDropdown
+    {
+        private readonly Action<OrderedSection> _turnOnSection;
+        private readonly List<OrderedSection> _sections;
+        private readonly string _name;
+
+        /// <summary>
+        /// Main constructor of the <see cref="OrderedSectionDropdown"/>
+        /// </summary>
+        /// <param name="name">name visualized in the header</param>
+        /// <param name="state">Advanced dropdown state</param>
+        /// <param name="sections">enumerable of <see cref="OrderedSection"/> to display in the dropdown</param>
+        /// <param name="turnOnSection">Function to call when selecting a section</param>
+        public OrderedSectionDropdown(string name, AdvancedDropdownState state, IEnumerable<OrderedSection> sections, Action<OrderedSection> turnOnSection) : base(state)
+        {
+            minimumSize = new Vector2(270, 300);
+            _turnOnSection = turnOnSection;
+            _sections = sections.ToList();
+            _name = name;
+        }
+    
+        protected override AdvancedDropdownItem BuildRoot()
+        {
+            var root = new AdvancedDropdownItem(_name);
+
+            _sections.Sort((s1, s2) =>
+            {
+                int order; 
+                
+                var s1Parts = s1.CustomPopupPath?.Split('/') ?? Array.Empty<string>();
+                var s2Parts = s2.CustomPopupPath?.Split('/') ?? Array.Empty<string>();
+                for (int i = 0; i < Math.Min(s2Parts.Length, s2Parts.Length); i++)
+                {
+                    bool s1Empty = string.IsNullOrWhiteSpace(s1Parts[i]);
+                    bool s2Empty = string.IsNullOrWhiteSpace(s2Parts[i]);
+                    if (s1Empty && !s2Empty) return 1;
+                    if (s2Empty && !s1Empty) return -1;
+                    order = string.Compare(s1Parts[i], s2Parts[i], StringComparison.Ordinal);
+                    if(order != 0) return order;
+                }
+
+                order = s2Parts.Length.CompareTo(s1Parts.Length);
+
+                if (order != 0) return order;
+
+                order = string.Compare(s1.Content.text, s2.Content.text, StringComparison.Ordinal);
+                return order;
+            });
+
+            foreach (OrderedSection section in _sections)
+                AddSectionToMenu(root, section);
+            return root;
+        }
+
+        protected override void ItemSelected(AdvancedDropdownItem item)
+        {
+            if (item is SectionDropdownItem secDrop)
+                _turnOnSection(secDrop.Section);
+        }
+        
+        private void AddSectionToMenu(AdvancedDropdownItem root, OrderedSection section)
+        {
+            var parent = root;
+            var shaderNameParts = section.CustomPopupPath?.Split('/');
+            if (shaderNameParts != null)
+                foreach (string folderName in shaderNameParts)
+                    parent = FindOrCreateChild(parent, folderName);
+
+            parent.AddChild(new SectionDropdownItem(section));
+            
+        }
+        
+        private AdvancedDropdownItem FindOrCreateChild(AdvancedDropdownItem parent, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return parent;
+            foreach (var child in parent.children)
+            {
+                if (child.name == name)
+                    return child;
+            }
+
+            var item = new AdvancedDropdownItem(name);
+            parent.AddChild(item);
+            return item;
+        }
+    }
+
+    /// <summary>
+    /// Dropdown item used by <see cref="OrderedSectionDropdown"/> for its items
+    /// </summary>
+    public class SectionDropdownItem : AdvancedDropdownItem
+    {
+        public readonly OrderedSection Section;
+        /// <summary>
+        /// Main constructor of <see cref="SectionDropdownItem"/>
+        /// </summary>
+        /// <param name="section"><see cref="OrderedSection"/> this item represents</param>
+        public SectionDropdownItem(OrderedSection section) : base(section.Content.text)
+        {
+            Section = section;
+        }
+    }
+}

--- a/Editor/Controls/Sections/OrderedSectionDropdown.cs.meta
+++ b/Editor/Controls/Sections/OrderedSectionDropdown.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 426491b1428d43f695b4e3b7b6b29499
+timeCreated: 1634839133

--- a/Editor/Controls/Sections/OrderedSectionGroup.cs
+++ b/Editor/Controls/Sections/OrderedSectionGroup.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+
 namespace VRLabs.SimpleShaderInspectors.Controls.Sections
 {
     /// <summary>
@@ -109,32 +111,35 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             DrawAddButton();
         }
 
+        //draw the add button and handles the dropdown when pressed
         private void DrawAddButton()
         {
             if (!(_areNewSectionsAvailable ?? true)) return;
             
             Color bCol = GUI.backgroundColor;
             GUI.backgroundColor = ButtonColor;
-            bool buttonPressed = GUILayout.Button(Content, ButtonStyle);
+            var buttonRect = GUILayoutUtility.GetRect(Content, ButtonStyle);
+            bool buttonPressed = GUI.Button(buttonRect, Content, ButtonStyle);
+            
             if (buttonPressed)
             {
-                GenericMenu menu = new GenericMenu();
+                List<OrderedSection> items = new List<OrderedSection>();
                 foreach (var section in Controls)
                     if (section.HasAtLeastOneMaterialDisabled())
-                        menu.AddItem(section.Content, false, TurnOnSection, section);
+                        items.Add(section);
                 
-                menu.ShowAsContext();
+                var dropdown = new OrderedSectionDropdown(Content.text, new AdvancedDropdownState(), items, TurnOnSection);
+                dropdown.Show(buttonRect);
             }
             GUI.backgroundColor = bCol;
         }
 
         /// <summary>
-        /// Turns on a section, setting it's index to the best number
+        /// Turns on a section, setting its index to the best number
         /// </summary>
-        /// <param name="sectionVariable">The section to turn on</param>
-        private void TurnOnSection(object sectionVariable)
+        /// <param name="section">The section to turn on</param>
+        private void TurnOnSection(OrderedSection section)
         {
-            var section = (OrderedSection)sectionVariable;
             section.SectionPosition = 753;
             section.HasSectionTurnedOn = true;
             _areNewSectionsAvailable = AreNewSectionsAvailable();

--- a/Editor/Localization.cs
+++ b/Editor/Localization.cs
@@ -84,11 +84,9 @@ namespace VRLabs.SimpleShaderInspectors
                         missingInfo.Add(selectedInfo);
                 }
                 control.Content = new GUIContent(selectedInfo.DisplayName, selectedInfo.Tooltip);
-
-                switch (control)
-                {
+                
                     // Find additional content in case it implements the IAdditionalLocalization interface.
-                    case IAdditionalLocalization additional:
+                    if(control is IAdditionalLocalization additional)
                         foreach (var content in additional.AdditionalContent)
                         {
                             string fullName = control.ControlAlias + "_" + content.Name;
@@ -107,13 +105,11 @@ namespace VRLabs.SimpleShaderInspectors
 
                             content.Content = new GUIContent(extraInfo.DisplayName, extraInfo.Tooltip);
                         }
-                        break;
 
                     // Recursively set property localization for all properties inside this control if it has the IControlContainer interface.
-                    case IControlContainer container:
+                    if(control is IControlContainer container)
                         if (recursive) missingInfo.AddRange(SetPropertiesLocalization(container.GetControlList(), propertyInfos));
-                        break;
-                }
+                
             }
             return missingInfo;
         }

--- a/Examples/Additive effects shader/Localization/Simple sectioned shader/English.json
+++ b/Examples/Additive effects shader/Localization/Simple sectioned shader/English.json
@@ -1,6 +1,26 @@
 {
     "Properties": [
         {
+            "Name": "Ordered1_Path",
+            "DisplayName": "AAA",
+            "Tooltip": ""
+        },
+        {
+            "Name": "Ordered2_Path",
+            "DisplayName": "BBB/CCC",
+            "Tooltip": ""
+        },
+        {
+            "Name": "Ordered3_Path",
+            "DisplayName": "BBB/CCC",
+            "Tooltip": ""
+        },
+        {
+            "Name": "Ordered4_Path",
+            "DisplayName": "",
+            "Tooltip": ""
+        },
+        {
             "Name": "OrderedLabel",
             "DisplayName": "Ordered Sections:",
             "Tooltip": ""


### PR DESCRIPTION
Now Ordered section groups add button will have a  searchable popup (like the one in the shader selection) for selecting sections.

The section path in the search popup can be localized.