### PR TITLE
Added ability for Texture controls derivative to have custom options

### DIFF
--- a/Editor/Autogenerated/VRLabs.SimpleShaderInspectors.Controls.Chainables.cs
+++ b/Editor/Autogenerated/VRLabs.SimpleShaderInspectors.Controls.Chainables.cs
@@ -129,9 +129,9 @@
             container.AddControl(control);
             return control;
         }
-        public static T SetShowUvOptions<T>(this T control, System.Boolean property) where T : TextureControl
+        public static T SetShowTilingAndOffset<T>(this T control, System.Boolean property) where T : TextureControl
         {
-            control.ShowUvOptions = property;
+            control.ShowTilingAndOffset = property;
             return control;
         }
         public static T SetHasHDRColor<T>(this T control, System.Boolean property) where T : TextureControl
@@ -139,24 +139,24 @@
             control.HasHDRColor = property;
             return control;
         }
-        public static T SetUVButtonStyle<T>(this T control, UnityEngine.GUIStyle property) where T : TextureControl
+        public static T SetOptionsButtonStyle<T>(this T control, UnityEngine.GUIStyle property) where T : TextureControl
         {
-            control.UVButtonStyle = property;
+            control.OptionsButtonStyle = property;
             return control;
         }
-        public static T SetUVAreaStyle<T>(this T control, UnityEngine.GUIStyle property) where T : TextureControl
+        public static T SetOptionsAreaStyle<T>(this T control, UnityEngine.GUIStyle property) where T : TextureControl
         {
-            control.UVAreaStyle = property;
+            control.OptionsAreaStyle = property;
             return control;
         }
-        public static T SetUVButtonColor<T>(this T control, UnityEngine.Color property) where T : TextureControl
+        public static T SetOptionsButtonColor<T>(this T control, UnityEngine.Color property) where T : TextureControl
         {
-            control.UVButtonColor = property;
+            control.OptionsButtonColor = property;
             return control;
         }
-        public static T SetUVAreaColor<T>(this T control, UnityEngine.Color property) where T : TextureControl
+        public static T SetOptionsAreaColor<T>(this T control, UnityEngine.Color property) where T : TextureControl
         {
-            control.UVAreaColor = property;
+            control.OptionsAreaColor = property;
             return control;
         }
 

--- a/Editor/Controls/GradientTextureControl.cs
+++ b/Editor/Controls/GradientTextureControl.cs
@@ -147,10 +147,12 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (!string.IsNullOrWhiteSpace(maxColorPropertyName))
                 _hasMaxValue = true;
             
+            Controls = new List<SimpleControl>();
+            
             GradientButtonStyle = Styles.Bubble;
             GradientEditorStyle = Styles.TextureBoxHeavyBorder;
             GradientSaveButtonStyle = Styles.Bubble;
-            ShowUvOptions = false;
+            ShowTilingAndOffset = false;
 
             GradientButtonColor = Color.white;
             GradientEditorColor = Color.white;
@@ -179,10 +181,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             else
                 materialEditor.TexturePropertySingleLine(Content, Property);
             
-            if (ShowUvOptions)
+            if (ShowTilingAndOffset || Controls.Count > 0)
             {
-                GUI.backgroundColor = UVButtonColor;
-                IsUVButtonPressed = EditorGUILayout.Toggle(IsUVButtonPressed, UVButtonStyle, GUILayout.Width(14.0f), GUILayout.Height(14.0f));
+                GUI.backgroundColor = OptionsButtonColor;
+                IsOptionsButtonPressed = EditorGUILayout.Toggle(IsOptionsButtonPressed, OptionsButtonStyle, GUILayout.Width(19.0f), GUILayout.Height(19.0f));
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
             }
             
@@ -209,13 +211,16 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             
             EditorGUILayout.EndHorizontal();
             
-            if (IsUVButtonPressed)
+            if (IsOptionsButtonPressed)
             {
-                GUI.backgroundColor = UVAreaColor;
-                EditorGUILayout.BeginVertical(UVAreaStyle);
+                GUI.backgroundColor = OptionsAreaColor;
+                EditorGUILayout.BeginVertical(OptionsAreaStyle);
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
                 EditorGUI.indentLevel++;
-                materialEditor.TextureScaleOffsetProperty(Property);
+                if (ShowTilingAndOffset)
+                    materialEditor.TextureScaleOffsetProperty(Property);
+                foreach (var control in Controls)
+                    control.DrawControl(materialEditor);
                 EditorGUI.indentLevel--;
                 EditorGUILayout.EndVertical();
             }

--- a/Editor/Controls/GradientTextureControl.cs
+++ b/Editor/Controls/GradientTextureControl.cs
@@ -214,6 +214,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (IsOptionsButtonPressed)
             {
                 GUI.backgroundColor = OptionsAreaColor;
+                EditorGUILayout.BeginHorizontal();
+                int previousIndent = EditorGUI.indentLevel;
+                GUILayout.Space(EditorGUI.indentLevel * 15);
+                EditorGUI.indentLevel = 0;
                 EditorGUILayout.BeginVertical(OptionsAreaStyle);
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
                 EditorGUI.indentLevel++;
@@ -223,6 +227,8 @@ namespace VRLabs.SimpleShaderInspectors.Controls
                     control.DrawControl(materialEditor);
                 EditorGUI.indentLevel--;
                 EditorGUILayout.EndVertical();
+                EditorGUI.indentLevel = previousIndent;
+                EditorGUILayout.EndHorizontal();
             }
             
             if (HasPropertyUpdated && (_hasMinValue || _hasMaxValue))

--- a/Editor/Controls/TextureControl.cs
+++ b/Editor/Controls/TextureControl.cs
@@ -174,6 +174,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (ShowTilingAndOffset || Controls.Count > 0 || HasCustomInlineContent)
                 EditorGUILayout.BeginHorizontal();
             
+            EditorGUILayout.BeginVertical();
             if (HasExtra2)
             {
                 materialEditor.TexturePropertySingleLine(Content, Property, AdditionalProperties[0].Property, AdditionalProperties[1].Property);
@@ -189,6 +190,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             {
                 materialEditor.TexturePropertySingleLine(Content, Property);
             }
+            EditorGUILayout.EndVertical();
             
             if (HasCustomInlineContent)
                 DrawSideContent(materialEditor);
@@ -208,15 +210,19 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (IsOptionsButtonPressed)
             {
                 GUI.backgroundColor = OptionsAreaColor;
+                EditorGUILayout.BeginHorizontal();
+                int previousIndent = EditorGUI.indentLevel;
+                GUILayout.Space(EditorGUI.indentLevel * 15);
+                EditorGUI.indentLevel = 0;
                 EditorGUILayout.BeginVertical(OptionsAreaStyle);
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
-                EditorGUI.indentLevel++;
                 if (ShowTilingAndOffset)
                     materialEditor.TextureScaleOffsetProperty(Property);
                 foreach (var control in Controls)
                     control.DrawControl(materialEditor);
-                EditorGUI.indentLevel--;
                 EditorGUILayout.EndVertical();
+                EditorGUI.indentLevel = previousIndent;
+                EditorGUILayout.EndHorizontal();
             }
         }
         

--- a/Editor/Controls/TextureControl.cs
+++ b/Editor/Controls/TextureControl.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -26,7 +27,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
     /// this.AddTextureControl("_TextureProperty", "_ColorProperty").SetShowUvOptions(true);
     /// </code>
     /// </example>
-    public class TextureControl : PropertyControl, IAdditionalProperties
+    public class TextureControl : PropertyControl, IAdditionalProperties, IControlContainer
     {
         /// <summary>
         /// Indicates if the control has the first extra property.
@@ -53,12 +54,20 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         protected bool HasCustomInlineContent = false;
 
         /// <summary>
-        /// Indicates if the uv button is pressed and the tiling and offset area is visible.
+        /// Indicates if the options button is pressed and the option area is visible.
         /// </summary>
         /// <value>
         /// True if the button is pressed, false otherwise.
         /// </value>
-        protected bool IsUVButtonPressed;
+        protected bool IsOptionsButtonPressed;
+        
+        /// <summary>
+        /// List of controls under this control's options.
+        /// </summary>
+        /// <value>
+        /// All controls that have been added by extension methods.
+        /// </value>
+        public List<SimpleControl> Controls { get; set; }
 
         /// <summary>
         /// Extra properties array. Implementation of <see cref="IAdditionalProperties"/>.
@@ -74,12 +83,12 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         public AdditionalProperty[] AdditionalProperties { get; set; }
 
         /// <summary>
-        /// Boolean that defines if the control will show up an additional button to have access to the texture tiling and offset options.
+        /// Boolean that defines if the control will show up the texture tiling and offset options in the options area.
         /// </summary>
         /// <value>
-        /// True if the control has to show the button for uv tiling and offset, false otherwise.
+        /// True if the control has to show the uv tiling and offset, false otherwise.
         /// </value>
-        [Chainable] public bool ShowUvOptions { get; set; }
+        [Chainable] public bool ShowTilingAndOffset { get; set; }
 
         /// <summary>
         /// Boolean that defines if the control needs to render the second material property as an hdr color field,
@@ -91,36 +100,36 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         [Chainable] public bool HasHDRColor { get; set; }
 
         /// <summary>
-        /// Style for the tiling and offset options button.
+        /// Style for the options button.
         /// </summary>
         /// <value>
-        /// GUIStyle used when displaying the tiling and offset button.
+        /// GUIStyle used when displaying the button.
         /// </value>
-        [Chainable] public GUIStyle UVButtonStyle { get; set; }
+        [Chainable] public GUIStyle OptionsButtonStyle { get; set; }
         
         /// <summary>
-        /// Style for the tiling and offset background area.
+        /// Style for the options background area.
         /// </summary>
         /// <value>
-        /// GUIStyle used for the background of the tiling and offset area.
+        /// GUIStyle used for the background of the options area.
         /// </value>
-        [Chainable] public GUIStyle UVAreaStyle { get; set; }
+        [Chainable] public GUIStyle OptionsAreaStyle { get; set; }
 
         /// <summary>
-        /// Color for the tiling and offset button.
+        /// Color for the options button.
         /// </summary>
         /// <value>
-        /// Color used when displaying the tiling and offset button.
+        /// Color used when displaying the options button.
         /// </value>
-        [Chainable] public Color UVButtonColor { get; set; }
+        [Chainable] public Color OptionsButtonColor { get; set; }
         
         /// <summary>
-        /// Background color for the uv button.
+        /// Background color for the options area.
         /// </summary>
         /// <value>
-        /// Color used when displaying the background for the tiling and offset area.
+        /// Color used when displaying the background for options area.
         /// </value>
-        [Chainable] public Color UVAreaColor { get; set; }
+        [Chainable] public Color OptionsAreaColor { get; set; }
 
         /// <summary>
         /// Default constructor of <see cref="TextureControl"/>
@@ -139,13 +148,15 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             AdditionalProperties[1] = new AdditionalProperty(extraPropertyName2, false);
             if (!string.IsNullOrWhiteSpace(extraPropertyName2))
                 HasExtra2 = true;
+            
+            Controls = new List<SimpleControl>();
 
-            UVButtonStyle = Styles.GearIcon;
-            UVAreaStyle = Styles.TextureBoxHeavyBorder;
-            UVButtonColor = Color.white;
-            UVAreaColor = Color.white;
+            OptionsButtonStyle = Styles.GearIcon;
+            OptionsAreaStyle = Styles.TextureBoxHeavyBorder;
+            OptionsButtonColor = Color.white;
+            OptionsAreaColor = Color.white;
 
-            ShowUvOptions = false;
+            ShowTilingAndOffset = false;
         }
 
         /// <summary>
@@ -160,7 +171,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         protected void DrawTextureSingleLine(MaterialEditor materialEditor)
         {
             EditorGUI.BeginChangeCheck();
-            if (ShowUvOptions|| HasCustomInlineContent)
+            if (ShowTilingAndOffset || Controls.Count > 0 || HasCustomInlineContent)
                 EditorGUILayout.BeginHorizontal();
             
             if (HasExtra2)
@@ -182,25 +193,28 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (HasCustomInlineContent)
                 DrawSideContent(materialEditor);
             
-            if (ShowUvOptions)
+            if (ShowTilingAndOffset || Controls.Count > 0)
             {
-                GUI.backgroundColor = UVButtonColor;
-                IsUVButtonPressed = EditorGUILayout.Toggle(IsUVButtonPressed, UVButtonStyle, GUILayout.Width(19.0f), GUILayout.Height(19.0f));
+                GUI.backgroundColor = OptionsButtonColor;
+                IsOptionsButtonPressed = EditorGUILayout.Toggle(IsOptionsButtonPressed, OptionsButtonStyle, GUILayout.Width(19.0f), GUILayout.Height(19.0f));
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
                 
             }
-            if (ShowUvOptions || HasCustomInlineContent)
+            if (ShowTilingAndOffset || Controls.Count > 0 || HasCustomInlineContent)
                 EditorGUILayout.EndHorizontal();
             
             HasPropertyUpdated = EditorGUI.EndChangeCheck();
             
-            if (IsUVButtonPressed)
+            if (IsOptionsButtonPressed)
             {
-                GUI.backgroundColor = UVAreaColor;
-                EditorGUILayout.BeginVertical(UVAreaStyle);
+                GUI.backgroundColor = OptionsAreaColor;
+                EditorGUILayout.BeginVertical(OptionsAreaStyle);
                 GUI.backgroundColor = SimpleShaderInspector.DefaultBgColor;
                 EditorGUI.indentLevel++;
-                materialEditor.TextureScaleOffsetProperty(Property);
+                if (ShowTilingAndOffset)
+                    materialEditor.TextureScaleOffsetProperty(Property);
+                foreach (var control in Controls)
+                    control.DrawControl(materialEditor);
                 EditorGUI.indentLevel--;
                 EditorGUILayout.EndVertical();
             }
@@ -209,5 +223,20 @@ namespace VRLabs.SimpleShaderInspectors.Controls
         protected virtual void DrawSideContent(MaterialEditor materialEditor)
         {
         }
+        
+        /// <summary>
+        /// Implementation needed by <see cref="IControlContainer"/> to add controls. All controls added are stored in <see cref="Controls"/>.
+        ///
+        /// These controls are going to be displayed inside the options area, after the tiling and offset option (it enabled).
+        /// </summary>
+        /// <param name="control">Control to add.</param>
+        public void AddControl(SimpleControl control) => Controls.Add(control);
+
+
+        /// <summary>
+        /// Implementation needed by <see cref="IControlContainer"/> to get the object's controls list.
+        /// </summary>
+        /// <returns><see cref="Controls"/></returns>
+        public IEnumerable<SimpleControl> GetControlList() => Controls;
     }
 }

--- a/Examples/Additive effects shader/Editor/SimpleSectionedShaderGUI.cs
+++ b/Examples/Additive effects shader/Editor/SimpleSectionedShaderGUI.cs
@@ -21,11 +21,11 @@ namespace VRLabs.SimpleShaderInspectorsExamples
         private OrderedSection _ordered4;
         protected override void Start()
         {
-            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowUvOptions(true);
+            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowTilingAndOffset(true);
 
             _layersSection = this.AddActivatableSection("_AdditionalMasksEnable").Alias("Layers header")
                 .SetBackgroundColor(Color.cyan).SetAreControlsInHeader(true);
-            _layersSection.AddTextureGeneratorControl("_AdditionalMasks").Alias("Layers mask").SetShowUvOptions(true);
+            _layersSection.AddTextureGeneratorControl("_AdditionalMasks").Alias("Layers mask").SetShowTilingAndOffset(true);
             _layersSection.AddSpaceControl();
 
             _rChannel = _layersSection.AddSection().Alias("Red channel");

--- a/Examples/Simple shader example/Editor/SimpleShaderGUI.cs
+++ b/Examples/Simple shader example/Editor/SimpleShaderGUI.cs
@@ -10,9 +10,9 @@ namespace VRLabs.SimpleShaderInspectorsExamples
         private ToggleListControl _toggle;
         protected override void Start()
         {
-            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowUvOptions(true);
+            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowTilingAndOffset(true);
             _toggle = this.AddToggleListControl("_EnableNormal").Alias("Normal toggle");
-            _toggle.AddTextureControl("_BumpMap", "_BumpIntensity").Alias("Normal map").SetShowUvOptions(true);
+            _toggle.AddTextureControl("_BumpMap", "_BumpIntensity").Alias("Normal map").SetShowTilingAndOffset(true);
         }
 
         protected override void Header()

--- a/Examples/Standard like shader/Editor/SimpleStandardShaderGUI.cs
+++ b/Examples/Standard like shader/Editor/SimpleStandardShaderGUI.cs
@@ -9,9 +9,9 @@ namespace VRLabs.SimpleShaderInspectorsExamples
     {
         protected override void Start()
         {
-            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowUvOptions(true);
-            this.AddTextureControl("_BumpMap", "_BumpIntensity").Alias("Normal map").SetShowUvOptions(true);
-            this.AddTextureGeneratorControl("_MultiMask").Alias("Multi mask").SetShowUvOptions(true);
+            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowTilingAndOffset(true);
+            this.AddTextureControl("_BumpMap", "_BumpIntensity").Alias("Normal map").SetShowTilingAndOffset(true);
+            this.AddTextureGeneratorControl("_MultiMask").Alias("Multi mask").SetShowTilingAndOffset(true);
             this.AddSpaceControl();
             this.AddLabelControl("MaskControls");
             this.AddPropertyControl("_Metallic");

--- a/Examples/Toon shader example/Editor/SimpleToonShaderGUI.cs
+++ b/Examples/Toon shader example/Editor/SimpleToonShaderGUI.cs
@@ -9,7 +9,7 @@ namespace VRLabs.SimpleShaderInspectorsExamples
     {
         protected override void Start()
         {
-            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowUvOptions(true);
+            this.AddTextureControl("_MainTex", "_Color").Alias("Main texture").SetShowTilingAndOffset(true);
             this.AddGradientTextureControl("_Ramp", "_RampColor").Alias("Ramp");
             this.AddPropertyControl("_ShadowIntensity").Alias("Shadow intensity");
         }


### PR DESCRIPTION
In TextureControl derivatives you can now add custom controls that will be viewed in the options area after the tiling and offset options. 

Tiling and offset options are also independently toggleable. 

The Options button now will appear when there is any option control to show or when tiling and offset should be shown (or both)