### PR TITLE
Made Different types of section titles more consistent

### DIFF
--- a/Editor/Controls/Sections/ActivatableSection.cs
+++ b/Editor/Controls/Sections/ActivatableSection.cs
@@ -137,7 +137,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             EditorGUI.BeginChangeCheck();
             Enabled = EditorGUILayout.Toggle(Enabled, GUILayout.MaxWidth(20.0f));
             HasActivatePropertyUpdated = EditorGUI.EndChangeCheck();
-            EditorGUILayout.LabelField(Content, LabelStyle);
+            float rectWidth = GUILayoutUtility.GetLastRect().width;
+            float rectHeight = GUILayoutUtility.GetRect(Content, LabelStyle).height;
+            Rect r2 = new Rect(r.x + rectWidth, r.y, r.width - (rectWidth * 2), Math.Max(rectHeight, r.height));
+            GUI.Label(r2, Content, LabelStyle);
 
             Show = GUI.Toggle(r, Show, GUIContent.none, new GUIStyle());
             HasPropertyUpdated = EditorGUI.EndChangeCheck();

--- a/Editor/Controls/Sections/ActivatableSection.cs
+++ b/Editor/Controls/Sections/ActivatableSection.cs
@@ -137,7 +137,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             EditorGUI.BeginChangeCheck();
             Enabled = EditorGUILayout.Toggle(Enabled, GUILayout.MaxWidth(20.0f));
             HasActivatePropertyUpdated = EditorGUI.EndChangeCheck();
-            float rectWidth = GUILayoutUtility.GetLastRect().width;
+            float rectWidth = ShowFoldoutArrow ? GUILayoutUtility.GetLastRect().width : 0;
             float rectHeight = GUILayoutUtility.GetRect(Content, LabelStyle).height;
             Rect r2 = new Rect(r.x + rectWidth, r.y, r.width - (rectWidth * 2), Math.Max(rectHeight, r.height));
             GUI.Label(r2, Content, LabelStyle);

--- a/Editor/Controls/Sections/OrderedSection.cs
+++ b/Editor/Controls/Sections/OrderedSection.cs
@@ -323,9 +323,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             if (ShowFoldoutArrow)
                 Show = EditorGUILayout.Toggle(Show, EditorStyles.foldout, GUILayout.MaxWidth(15.0f));
             
-            Rect temp = GUILayoutUtility.GetLastRect();
-            Rect r2 = new Rect(r.x + temp.width, r.y, r.width - (temp.width * 2), r.height);
-            EditorGUI.LabelField(r2, Content, LabelStyle);
+            float rectWidth = GUILayoutUtility.GetLastRect().width;
+            float rectHeight = GUILayoutUtility.GetRect(Content, LabelStyle).height;
+            Rect r2 = new Rect(r.x + rectWidth, r.y, r.width - (rectWidth * 2), Math.Max(rectHeight, r.height));
+            GUI.Label(r2, Content, LabelStyle);
             GUILayout.FlexibleSpace();
 
             DrawSideButtons();

--- a/Editor/Controls/Sections/OrderedSection.cs
+++ b/Editor/Controls/Sections/OrderedSection.cs
@@ -323,7 +323,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             if (ShowFoldoutArrow)
                 Show = EditorGUILayout.Toggle(Show, EditorStyles.foldout, GUILayout.MaxWidth(15.0f));
             
-            float rectWidth = GUILayoutUtility.GetLastRect().width;
+            float rectWidth = ShowFoldoutArrow ? GUILayoutUtility.GetLastRect().width : 0;
             float rectHeight = GUILayoutUtility.GetRect(Content, LabelStyle).height;
             Rect r2 = new Rect(r.x + rectWidth, r.y, r.width - (rectWidth * 2), Math.Max(rectHeight, r.height));
             GUI.Label(r2, Content, LabelStyle);

--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -271,7 +271,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             if (ShowFoldoutArrow)
                 Show = EditorGUILayout.Toggle(Show, EditorStyles.foldout, GUILayout.MaxWidth(15.0f));
             
-            float rectWidth = GUILayoutUtility.GetLastRect().width;
+            float rectWidth = ShowFoldoutArrow ? GUILayoutUtility.GetLastRect().width : 0;
             float rectHeight = GUILayoutUtility.GetRect(Content, LabelStyle).height;
             Rect r2 = new Rect(r.x + rectWidth, r.y, r.width - (rectWidth * 2), Math.Max(rectHeight, r.height));
             GUI.Label(r2, Content, LabelStyle);

--- a/Editor/Controls/Sections/Section.cs
+++ b/Editor/Controls/Sections/Section.cs
@@ -271,7 +271,10 @@ namespace VRLabs.SimpleShaderInspectors.Controls.Sections
             if (ShowFoldoutArrow)
                 Show = EditorGUILayout.Toggle(Show, EditorStyles.foldout, GUILayout.MaxWidth(15.0f));
             
-            EditorGUILayout.LabelField(Content, LabelStyle);
+            float rectWidth = GUILayoutUtility.GetLastRect().width;
+            float rectHeight = GUILayoutUtility.GetRect(Content, LabelStyle).height;
+            Rect r2 = new Rect(r.x + rectWidth, r.y, r.width - (rectWidth * 2), Math.Max(rectHeight, r.height));
+            GUI.Label(r2, Content, LabelStyle);
             //DrawUpDownButtons();
             //isEnabled = EditorGUILayout.Toggle(isEnabled, TSConstants.Styles.deleteStyle, GUILayout.MaxWidth(15.0f));
 


### PR DESCRIPTION
Based on the settings of the section header, labels would look missaligned in mixed contexts, especially using the default centered alignment for the labels.

This pr aims at fixing said issue giving it a more unified look

Before:
![Unity_JYvgknvVjH](https://user-images.githubusercontent.com/12004047/141881223-4cbd9770-f0b1-47f6-90e2-0444ecc20af3.png)

After:
![immagine](https://user-images.githubusercontent.com/12004047/141881511-3dec0ada-ac6d-4a3a-9e50-80a4cb4c18b8.png)
