### PR TITLE
Fix to gradient editor keyframe swap when editing values manually

### DIFF
--- a/Editor/Controls/GradientTextureControl.cs
+++ b/Editor/Controls/GradientTextureControl.cs
@@ -356,9 +356,9 @@ namespace VRLabs.SimpleShaderInspectors.Controls
             if (!col.Equals(_gradient.Keys[_selectedKeyIndex].Color))
                 _gradient.UpdateKeyColor(_selectedKeyIndex, col);
 
-            float time = EditorGUILayout.FloatField(_gradient.Keys[_selectedKeyIndex].Time);
-            if (time != _gradient.Keys[_selectedKeyIndex].Time)
-                _gradient.UpdateKeyTime(_selectedKeyIndex, time);
+            float time = (float)Math.Round(EditorGUILayout.FloatField(_gradient.Keys[_selectedKeyIndex].Time), 3);
+            if (Math.Abs(time - _gradient.Keys[_selectedKeyIndex].Time) > 0.0001)
+                _selectedKeyIndex = _gradient.UpdateKeyTime(_selectedKeyIndex, time);
 
             _rampWidth = (GradientWidth)EditorGUILayout.EnumPopup(_rampWidth);
             if ((int)_rampWidth != _gradient.GetTexture().width)
@@ -461,6 +461,7 @@ namespace VRLabs.SimpleShaderInspectors.Controls
 
         private void TranslateTextureToGradient(Texture2D texture)
         {
+            if (texture == null) return;
             if (!texture.isReadable)
                 SSIHelper.SetTextureImporterReadable(texture, true);
             


### PR DESCRIPTION
Whever someone would manually set the time value of the gradient keyframe, if the change would make that keyframe would end up before/after another keyframe, it would lose the reference due to a missed index reference change